### PR TITLE
Block delimiter rule change

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -2142,9 +2142,7 @@ Style/BlockDelimiters:
                 Prefer {...} over do...end for single-line blocks.
   StyleGuide: '#single-line-blocks'
   Enabled: true
-  VersionAdded: '0.30'
-  VersionChanged: '0.35'
-  EnforcedStyle: line_count_based
+  EnforcedStyle: braces_for_chaining
   SupportedStyles:
     # The `line_count_based` style enforces braces around single line blocks and
     # do..end around multi-line blocks.


### PR DESCRIPTION
Use `brace_for_chaining` rule, as it looks more familiar having `}.something` than `end.something`