### PR TITLE
Change indentation to match defaul rubymine, disable line length

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -690,7 +690,7 @@ Layout/LeadingEmptyLines:
 
 Layout/LineLength:
   Description: 'Limit lines to 125 characters.'
-  Enabled: true
+  Enabled: false
   AutoCorrect: false
   Max: 125
   # To make it possible to copy or click on URIs in the code, we allow lines
@@ -815,7 +815,7 @@ Layout/MultilineMethodCallIndentation:
                  Checks indentation of method calls with the dot operator
                  that span more than one line.
   Enabled: true
-  EnforcedStyle: indented
+  EnforcedStyle: indented_relative_to_receiver
   SupportedStyles:
     - aligned
     - indented


### PR DESCRIPTION
# Background

## Did you make sure to?
### Project Management
- [x] Review it as needed with the technical team leader?
- [x] Attach the PR to the Trello card?

### PR
- [x] Assign yourself to the PR
- [x] Add at least one reviewer

### Before-Merge
- [x] Update the repos dependent on those rules - delete the current cached rubocop.yml, and run `rubocop` again to refresh
- [x] Validate changes against affected repositories, and if needed, prepare PRs to update repositories according to changes

### Post-Merge
- [ ] Verify that your Trello card was moved to today's release and that it was announced in #releases slack channel
