### PR TITLE
Relax rules for tailor core

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1650,7 +1650,7 @@ Lint/ReturnInVoidContext:
 
 Lint/SafeNavigationChain:
   Description: 'Do not chain ordinary method call after safe navigation operator.'
-  Enabled: true
+  Enabled: false
   Severity: error
   VersionAdded: '0.47'
   VersionChanged: '0.77'
@@ -1850,7 +1850,7 @@ Metrics/AbcSize:
 
 Metrics/BlockLength:
   Description: 'Avoid long blocks with many lines.'
-  Enabled: true
+  Enabled: false
   Severity: error
   CountComments: false  # count full line comments?
   Max: 80
@@ -1895,7 +1895,7 @@ Metrics/CyclomaticComplexity:
 Metrics/MethodLength:
   Description: 'Avoid methods longer than 80 lines of code.'
   StyleGuide: '#short-methods'
-  Enabled: true
+  Enabled: false
   Severity: error
   CountComments: false  # count full line comments?
   Max: 80
@@ -1915,7 +1915,7 @@ Metrics/ParameterLists:
   StyleGuide: '#too-many-params'
   Enabled: true
   Severity: error
-  Max: 3
+  Max: 5
   CountKeywordArgs: false
   Exclude:
     # Workers `perform` method cant transform to keyword
@@ -1942,7 +1942,7 @@ Migration/DepartmentName:
 Naming/AccessorMethodName:
   Description: Check the naming of accessor methods for get_/set_.
   StyleGuide: '#accessor_mutator_method_names'
-  Enabled: true
+  Enabled: false
   Severity: error
   VersionAdded: '0.50'
 
@@ -2078,7 +2078,7 @@ Naming/HeredocDelimiterNaming:
 Naming/MemoizedInstanceVariableName:
   Description: >-
     Memoized method name should match memo instance variable name.
-  Enabled: true
+  Enabled: false
   Severity: error
   VersionAdded: '0.53'
   VersionChanged: '0.58'
@@ -2110,7 +2110,7 @@ Naming/MethodParameterName:
   Description: >-
                  Checks for method parameter names that contain capital letters,
                  end in numbers, or do not meet a minimal length.
-  Enabled: true
+  Enabled: false
   Severity: error
   VersionAdded: '0.53'
   VersionChanged: '0.77'
@@ -2512,7 +2512,7 @@ Style/ClassMethods:
 Style/ClassVars:
   Description: 'Avoid the use of class variables.'
   StyleGuide: '#no-class-vars'
-  Enabled: true
+  Enabled: false
   Severity: error
   VersionAdded: '0.13'
 
@@ -2802,7 +2802,7 @@ Style/FloatDivision:
   Description: 'For performing float division, coerce one side only.'
   StyleGuide: '#float-division'
   Reference: 'https://github.com/rubocop-hq/ruby-style-guide/issues/628'
-  Enabled: true
+  Enabled: false
   Severity: error
   VersionAdded: '0.72'
   EnforcedStyle: single_coerce
@@ -2937,7 +2937,7 @@ Style/IfUnlessModifier:
                  Favor modifier if/unless usage when you have a
                  single-line body.
   StyleGuide: '#if-as-a-modifier'
-  Enabled: true
+  Enabled: false
   Severity: error
   VersionAdded: '0.9'
   VersionChanged: '0.30'
@@ -3178,7 +3178,7 @@ Style/ModuleFunction:
 Style/MultilineBlockChain:
   Description: 'Avoid multi-line chains of blocks.'
   StyleGuide: '#single-line-blocks'
-  Enabled: true
+  Enabled: false
   Severity: error
   VersionAdded: '0.13'
 
@@ -3420,7 +3420,7 @@ Style/NumericPredicate:
   # of the variables which rubocop doesn't have.
   SafeAutoCorrect: false
   AutoCorrect: false
-  Enabled: true
+  Enabled: false
   Severity: error
   EnforcedStyle: comparison
   SupportedStyles:

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -59,6 +59,8 @@ AllCops:
     - 'vendor/**/*'
     - '.git/**/*'
     - 'bin/**/*'
+    - 'Dockerfile'
+    - 'Dockerfile.ruby'
   # Default formatter will be used if no `-f/--format` option is given.
   DefaultFormatter: progress
   # Cop names are displayed in offense messages by default. Change behavior
@@ -1280,7 +1282,7 @@ Lint/BooleanSymbol:
 
 Lint/CircularArgumentReference:
   Description: "Default values in optional keyword arguments and optional ordinal arguments should not refer back to the name of the argument."
-  Enabled: true
+  Enabled: false
   Severity: error
   VersionAdded: '0.33'
 
@@ -1650,7 +1652,7 @@ Lint/ReturnInVoidContext:
 
 Lint/SafeNavigationChain:
   Description: 'Do not chain ordinary method call after safe navigation operator.'
-  Enabled: false
+  Enabled: true
   Severity: error
   VersionAdded: '0.47'
   VersionChanged: '0.77'
@@ -1833,7 +1835,7 @@ Lint/UselessSetterCall:
 
 Lint/Void:
   Description: 'Possible use of operator/literal/variable in void context.'
-  Enabled: true
+  Enabled: false
   Severity: error
   VersionAdded: '0.9'
   CheckForMethodsWithNoSideEffects: false
@@ -1871,7 +1873,7 @@ Metrics/BlockNesting:
   VersionAdded: '0.25'
   VersionChanged: '0.47'
   CountBlocks: false
-  Max: 3
+  Max: 4
 
 Metrics/ClassLength:
   Description: 'Avoid classes longer than 100 lines of code.'
@@ -1915,7 +1917,7 @@ Metrics/ParameterLists:
   StyleGuide: '#too-many-params'
   Enabled: true
   Severity: error
-  Max: 5
+  Max: 7
   CountKeywordArgs: false
   Exclude:
     # Workers `perform` method cant transform to keyword
@@ -1998,7 +2000,9 @@ Naming/FileName:
   VersionAdded: '0.50'
   # Camel case file names listed in `AllCops:Include` and all file names listed
   # in `AllCops:Exclude` are excluded by default. Add extra excludes here.
-  Exclude: []
+  Exclude: [
+    "Gemfile.ruby"
+  ]
   # When `true`, requires that each source file should define a class or module
   # with a name which matches the file name (converted to ... case).
   # It further expects it to be nested inside modules which match the names
@@ -2875,7 +2879,7 @@ Style/GlobalVars:
   Description: 'Do not introduce global variables.'
   StyleGuide: '#instance-vars'
   Reference: 'https://www.zenspider.com/ruby/quickref.html'
-  Enabled: true
+  Enabled: false
   Severity: error
   VersionAdded: '0.13'
   # Built-in global variables are allowed by default.
@@ -3420,7 +3424,7 @@ Style/NumericPredicate:
   # of the variables which rubocop doesn't have.
   SafeAutoCorrect: false
   AutoCorrect: false
-  Enabled: false
+  Enabled: true
   Severity: error
   EnforcedStyle: comparison
   SupportedStyles:


### PR DESCRIPTION
# Background
To have a workable version for tailor-core, we have to relax some rules.
They are divided as such:

## To be enabled in the future
- ParameterLists - lower restriction back to 3.
- MemoizedInstanceVariableName
- MethodParameterName (to make sure no parameters named `a` or `x`)
- GlobalVars
- CircularArgumentReference

## Disabled forever
- Void
- BlockLength
- MethodLength
- AccessorMethodName
- ClassVars
- FloatDivision
- IfUnlessModifier
- MultilineBlockChain

## Did you make sure to?
### Project Management
- [x] Review it as needed with the technical team leader?
- [x] Attach the PR to the Trello card?

### PR
- [x] Assign yourself to the PR
- [x] Add at least one reviewer

### Before-Merge
- [x] Update the repos dependent on those rules - delete the current cached rubocop.yml, and run `rubocop` again to refresh
- [x] Validate changes against affected repositories, and if needed, prepare PRs to update repositories according to changes

### Post-Merge
- [ ] Verify that your Trello card was moved to today's release and that it was announced in #releases slack channel
