### PR TITLE
Disallow prefixed unless

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -3267,7 +3267,7 @@ Style/NegatedIf:
   Severity: error
   VersionAdded: '0.20'
   VersionChanged: '0.48'
-  EnforcedStyle: both
+  EnforcedStyle: postfix
   SupportedStyles:
     # both: prefix and postfix negated `if` should both use `unless`
     # prefix: only use `unless` for negated `if` statements positioned before the body of the statement


### PR DESCRIPTION
prefixed unlesses open up the possibility for more complex block comparisons that are sometimes hard to follow

I propose to disallow prefix unless altogether
```
# enforces `unless` for just `postfix` conditionals
# bad
bar if !foo

# good
bar unless foo

# good
if !foo
  bar
end
```

 