### PR TITLE
Remove Style/BracesAroundHashParameters

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -2434,25 +2434,6 @@ Style/BlockDelimiters:
   #   collection.each do |element| puts element end
   AllowBracesOnProceduralOneLiners: false
 
-Style/BracesAroundHashParameters:
-  Description: 'Enforce braces style around hash parameters.'
-  Enabled: true
-  Severity: error
-  VersionAdded: '0.14.1'
-  VersionChanged: '0.28'
-  EnforcedStyle: no_braces
-  SupportedStyles:
-    # The `braces` style enforces braces around all method parameters that are
-    # hashes.
-    - braces
-    # The `no_braces` style checks that the last parameter doesn't have braces
-    # around it.
-    - no_braces
-    # The `context_dependent` style checks that the last parameter doesn't have
-    # braces around it, but requires braces if the second to last parameter is
-    # also a hash literal.
-    - context_dependent
-
 Style/CaseEquality:
   Description: 'Avoid explicit use of the case equality operator(===).'
   StyleGuide: '#no-case-equality'


### PR DESCRIPTION
# Background

Since Ruby 2.7, the existence of curly braces on the last argument has meaning.

It means, the following codes have different meanings.

```rb
foo(x: 1) # x: 1 is a keyword argument
foo({x: 1}) # {x: 1} is a hash
```
There are the correct pairs of method definitions and method calls.

```rb
def foo(x: 1)
end
foo(x: 1)

def foo(hash)
end
foo({x: 1})
```

For more detail https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

* Taken from https://github.com/rubocop-hq/rubocop/issues/7641

# Notable Changes
* remove Style/BracesAroundHashParameters