### PR TITLE
Re-apply some rules back

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1907,11 +1907,11 @@ Metrics/ModuleLength:
   Max: 100
 
 Metrics/ParameterLists:
-  Description: 'Avoid parameter lists longer than 3 parameters. Use keyword args instead.'
+  Description: 'Avoid parameter lists longer than 5 parameters. Use keyword args instead.'
   StyleGuide: '#too-many-params'
   Enabled: true
   Severity: error
-  Max: 3
+  Max: 5
   CountKeywordArgs: false
   Exclude:
     # Workers `perform` method cant transform to keyword

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1282,7 +1282,7 @@ Lint/BooleanSymbol:
 
 Lint/CircularArgumentReference:
   Description: "Default values in optional keyword arguments and optional ordinal arguments should not refer back to the name of the argument."
-  Enabled: false
+  Enabled: true
   Severity: error
   VersionAdded: '0.33'
 
@@ -1907,11 +1907,11 @@ Metrics/ModuleLength:
   Max: 100
 
 Metrics/ParameterLists:
-  Description: 'Avoid parameter lists longer than 2 parameters. Use keyword args instead.'
+  Description: 'Avoid parameter lists longer than 3 parameters. Use keyword args instead.'
   StyleGuide: '#too-many-params'
   Enabled: true
   Severity: error
-  Max: 7
+  Max: 3
   CountKeywordArgs: false
   Exclude:
     # Workers `perform` method cant transform to keyword
@@ -2076,7 +2076,7 @@ Naming/HeredocDelimiterNaming:
 Naming/MemoizedInstanceVariableName:
   Description: >-
     Memoized method name should match memo instance variable name.
-  Enabled: false
+  Enabled: true
   Severity: error
   VersionAdded: '0.53'
   VersionChanged: '0.58'
@@ -2108,7 +2108,7 @@ Naming/MethodParameterName:
   Description: >-
                  Checks for method parameter names that contain capital letters,
                  end in numbers, or do not meet a minimal length.
-  Enabled: false
+  Enabled: true
   Severity: error
   VersionAdded: '0.53'
   VersionChanged: '0.77'
@@ -2854,7 +2854,7 @@ Style/GlobalVars:
   Description: 'Do not introduce global variables.'
   StyleGuide: '#instance-vars'
   Reference: 'https://www.zenspider.com/ruby/quickref.html'
-  Enabled: false
+  Enabled: true
   Severity: error
   VersionAdded: '0.13'
   # Built-in global variables are allowed by default.


### PR DESCRIPTION
# Background
Reapply the next rules:
- `Metrics/ParameterLists` - allow max of 3 non key parameters
- `Naming/MemoizedInstanceVariableName` - turn back on
- `Naming/MethodParameterName` - turn back on
- `Style/GlobalVars` - turn back on
- `Lint/CircularArgumentReference` - turn back on

## Did you make sure to?
### Project Management
- [ ] Review it as needed with the technical team leader?
- [x] Attach the PR to the Trello card?

### PR
- [x] Assign yourself to the PR
- [x] Add at least one reviewer

### Before-Merge
- [ ] Update the repos dependent on those rules - delete the current cached rubocop.yml, and run `rubocop` again to refresh
- [ ] Validate changes against affected repositories, and if needed, prepare PRs to update repositories according to changes

### Post-Merge
- [ ] Verify that your Trello card was moved to today's release and that it was announced in #releases slack channel
