### PR TITLE
Fix enabled flag for Layout/SpaceBeforeBrackets rule

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1266,7 +1266,7 @@ Layout/SpaceBeforeBlockBraces:
 Layout/SpaceBeforeBrackets:
   Description: 'Checks for receiver with a space before the opening brackets.'
   StyleGuide: '#space-in-brackets-access'
-  Enabled: pending
+  Enabled: false
   VersionAdded: '<<next>>'
   Safe: false
 


### PR DESCRIPTION
# Background
Fix enabled flag for Layout/SpaceBeforeBrackets rule. Fix this error: `Property Enabled of cop Layout/SpaceBeforeBrackets is supposed to be a boolean and pending is not.`

## Did you make sure to?
### Project Management
- [ ] Review it as needed with the technical team leader?
- [ ] Attach the PR to the Trello card?

### PR
- [x] Assign yourself to the PR
- [x] Add at least one reviewer

### Before-Merge
- [ ] Update the repos dependent on those rules - delete the current cached rubocop.yml, and run `rubocop` again to refresh
- [ ] Validate changes against affected repositories, and if needed, prepare PRs to update repositories according to changes

### Post-Merge
- [ ] Verify that your Trello card was moved to today's release and that it was announced in #releases slack channel
