### PR TITLE
Remove safe auto-correct from Style/InfiniteLoop

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -3671,7 +3671,6 @@ Style/InfiniteLoop:
   Severity: error
   VersionAdded: '0.26'
   VersionChanged: '0.61'
-  SafeAutoCorrect: true
 
 Style/InlineComment:
   Description: 'Avoid trailing inline comments.'


### PR DESCRIPTION
# Background
Fix:
```
error: Unsafe cops cannot have a safe auto-correction (section Style/InfiniteLoop in .rubocop-https---raw-githubusercontent-com-TailorBrands-tailor-rubocop-master-rubocop-yml)
```

## Did you make sure to?
### Project Management
- [ ] Review it as needed with the technical team leader?
- [ ] Attach the PR to the Trello card?

### PR
- [ ] Assign yourself to the PR
- [ ] Add at least one reviewer

### Before-Merge
- [x] Update the repos dependent on those rules - delete the current cached rubocop.yml, and run `rubocop` again to refresh
- [x] Validate changes against affected repositories, and if needed, prepare PRs to update repositories according to changes

### Post-Merge
- [ ] Verify that your Trello card was moved to today's release and that it was announced in #releases slack channel
