### PR TITLE
Fix obselete warnings

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -2328,7 +2328,7 @@ Metrics/BlockLength:
   Severity: error
   CountComments: false  # count full line comments?
   Max: 80
-  ExcludedMethods:
+  IgnoredMethods:
     # By default, exclude the `#refine` method, as it tends to have larger
     # associated blocks.
     - refine
@@ -2373,7 +2373,7 @@ Metrics/MethodLength:
   Severity: error
   CountComments: false  # count full line comments?
   Max: 80
-  ExcludedMethods: []
+  IgnoredMethods: []
   Exclude:
     # Migrations are one time thing
     - 'db/migrate/**/*'
@@ -4757,7 +4757,6 @@ Style/SymbolProc:
   Description: 'Use symbols as procs instead of blocks when possible.'
   Enabled: true
   Severity: error
-  SafeAutoCorrect: false
   Safe: false
   VersionAdded: '0.26'
   VersionChanged: '1.5'


### PR DESCRIPTION
# Background
Fix obsolete warnings:
```
Warning: obsolete parameter `ExcludedMethods` (for `Metrics/BlockLength`) found in .rubocop-https---raw-githubusercontent-com-TailorBrands-tailor-rubocop-master-rubocop-yml
`ExcludedMethods` has been renamed to `IgnoredMethods`.
obsolete parameter `ExcludedMethods` (for `Metrics/MethodLength`) found in .rubocop-https---raw-githubusercontent-com-TailorBrands-tailor-rubocop-master-rubocop-yml
`ExcludedMethods` has been renamed to `IgnoredMethods`.
Warning: Style/SymbolProc does not support SafeAutoCorrect parameter.

Supported parameters are:

  - Enabled
  - IgnoredMethods
Warning: obsolete parameter `ExcludedMethods` (for `Metrics/BlockLength`) found in .rubocop.yml
`ExcludedMethods` has been renamed to `IgnoredMethods`.
obsolete parameter `ExcludedMethods` (for `Metrics/MethodLength`) found in .rubocop.yml
`ExcludedMethods` has been renamed to `IgnoredMethods`.
Warning: Style/SymbolProc does not support SafeAutoCorrect parameter.
```

## Did you make sure to?
### Project Management
- [ ] Review it as needed with the technical team leader?
- [ ] Attach the PR to the Trello card?

### PR
- [x] Assign yourself to the PR
- [x] Add at least one reviewer

### Before-Merge
- [ ] Update the repos dependent on those rules - delete the current cached rubocop.yml, and run `rubocop` again to refresh
- [ ] Validate changes against affected repositories, and if needed, prepare PRs to update repositories according to changes

### Post-Merge
- [ ] Verify that your Trello card was moved to today's release and that it was announced in #releases slack channel
