### PR TITLE
Disable Lint/MissingSuper Rule

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1829,7 +1829,7 @@ Lint/MissingSuper:
   Description: >-
     This cop checks for the presence of constructors and lifecycle callbacks
     without calls to `super`'.
-  Enabled: true
+  Enabled: false
   VersionAdded: '0.89'
   VersionChanged: '1.4'
 


### PR DESCRIPTION
# Background
Disable Lint/MissingSuper Rule

## Did you make sure to?
### Project Management
- [ ] Review it as needed with the technical team leader?
- [ ] Attach the PR to the Trello card?

### PR
- [x] Assign yourself to the PR
- [x] Add at least one reviewer

### Before-Merge
- [ ] Update the repos dependent on those rules - delete the current cached rubocop.yml, and run `rubocop` again to refresh
- [ ] Validate changes against affected repositories, and if needed, prepare PRs to update repositories according to changes

### Post-Merge
- [ ] Verify that your Trello card was moved to today's release and that it was announced in #releases slack channel
