### PR TITLE
Fix description for Migration/DepartmentName rule

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -2407,9 +2407,7 @@ Metrics/PerceivedComplexity:
 ################## Migration #############################
 
 Migration/DepartmentName:
-  Description: >-
-    Check that cop names in rubocop:disable (etc) comments are
-    given with department name.
+  Description: 'Check that cop names in rubocop:disable (etc) comments are given with department name.'
   Enabled: false
   VersionAdded: '0.75'
 


### PR DESCRIPTION
# Background
Fix description for Migration/DepartmentName rule

## Did you make sure to?
### Project Management
- [ ] Review it as needed with the technical team leader?
- [ ] Attach the PR to the Trello card?

### PR
- [x] Assign yourself to the PR
- [x] Add at least one reviewer

### Before-Merge
- [ ] Update the repos dependent on those rules - delete the current cached rubocop.yml, and run `rubocop` again to refresh
- [ ] Validate changes against affected repositories, and if needed, prepare PRs to update repositories according to changes

### Post-Merge
- [ ] Verify that your Trello card was moved to today's release and that it was announced in #releases slack channel
