### PR TITLE
Disable all pending rules

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1450,7 +1450,7 @@ Layout/TrailingWhitespace:
 
 Lint/AmbiguousAssignment:
   Description: 'Checks for mistyped shorthand assignments.'
-  Enabled: pending
+  Enabled: false
   VersionAdded: '<<next>>'
 
 Lint/AmbiguousBlockAssociation:
@@ -1580,7 +1580,7 @@ Lint/DisjunctiveAssignmentInConstructor:
 
 Lint/DuplicateBranch:
   Description: Checks that there are no repeated bodies within `if/unless`, `case-when` and `rescue` constructs.
-  Enabled: pending
+  Enabled: false
   VersionAdded: '1.3'
 
 Lint/DuplicateCaseCondition:
@@ -1609,7 +1609,7 @@ Lint/DuplicateMethods:
 
 Lint/DuplicateRegexpCharacterClassElement:
   Description: 'Checks for duplicate elements in Regexp character classes.'
-  Enabled: pending
+  Enabled: false
   VersionAdded: '1.1'
 
 Lint/DuplicateRequire:
@@ -1637,7 +1637,7 @@ Lint/ElseLayout:
 
 Lint/EmptyBlock:
   Description: 'This cop checks for blocks without a body.'
-  Enabled: pending
+  Enabled: false
   VersionAdded: '1.1'
   VersionChanged: '1.3'
   AllowComments: true
@@ -1645,7 +1645,7 @@ Lint/EmptyBlock:
 
 Lint/EmptyClass:
   Description: 'Checks for classes and metaclasses without a body.'
-  Enabled: pending
+  Enabled: false
   VersionAdded: '1.3'
   AllowComments: false
 
@@ -1869,7 +1869,7 @@ Lint/NextWithoutAccumulator:
 
 Lint/NoReturnInBeginEndBlocks:
   Description: 'Do not `return` inside `begin..end` blocks in assignment contexts.'
-  Enabled: pending
+  Enabled: false
   VersionAdded: '1.2'
 
 Lint/NonDeterministicRequireOrder:
@@ -2148,7 +2148,7 @@ Lint/Syntax:
 
 Lint/ToEnumArguments:
   Description: 'This cop ensures that `to_enum`/`enum_for`, called for the current method, has correct arguments.'
-  Enabled: pending
+  Enabled: false
   VersionAdded: '1.1'
 
 Lint/ToJSON:
@@ -2176,7 +2176,7 @@ Lint/UnderscorePrefixedVariableName:
 
 Lint/UnexpectedBlockArity:
   Description: 'Looks for blocks that have fewer arguments that the calling method expects.'
-  Enabled: pending
+  Enabled: false
   Safe: false
   VersionAdded: '1.5'
   Methods:
@@ -2199,7 +2199,7 @@ Lint/UnifiedInteger:
 
 Lint/UnmodifiedReduceAccumulator:
   Description: Checks for `reduce` or `inject` blocks that do not update the accumulator each iteration.
-  Enabled: pending
+  Enabled: false
   VersionAdded: '1.1'
   VersionChanged: '1.5'
 
@@ -2792,7 +2792,7 @@ Style/AndOr:
 Style/ArgumentsForwarding:
   Description: 'Use arguments forwarding.'
   StyleGuide: '#arguments-forwarding'
-  Enabled: pending
+  Enabled: false
   AllowOnlyRestArgument: true
   VersionAdded: '1.1'
 
@@ -3088,7 +3088,7 @@ Style/ClassVars:
 
 Style/CollectionCompact:
   Description: 'Use `{Array,Hash}#{compact,compact!}` instead of custom logic to reject nils.'
-  Enabled: pending
+  Enabled: false
   Safe: false
   VersionAdded: '1.2'
   VersionChanged: '1.3'
@@ -3269,7 +3269,7 @@ Style/DocumentDynamicEvalDefinition:
     When using `class_eval` (or other `eval`) with string interpolation,
     add a comment block showing its appearance if interpolated.
   StyleGuide: '#eval-comment-docs'
-  Enabled: pending
+  Enabled: false
   VersionAdded: '1.1'
   VersionChanged: '1.3'
 
@@ -3560,6 +3560,13 @@ Style/HashEachMethods:
   Enabled: true
   VersionAdded: '0.80'
   Safe: false
+
+Style/HashExcept:
+  Description: >-
+    Checks for usages of `Hash#reject`, `Hash#select`, and `Hash#filter` methods
+    that can be replaced with `Hash#except` method.
+  Enabled: false
+  VersionAdded: '1.7'
 
 Style/HashLikeCase:
   Description: >-
@@ -3982,7 +3989,7 @@ Style/NegatedIfElseCondition:
   Description: >-
     This cop checks for uses of `if-else` and ternary operators with a negated condition
     which can be simplified by inverting condition and swapping branches.
-  Enabled: pending
+  Enabled: false
   VersionAdded: '1.2'
 
 Style/NegatedUnless:
@@ -4081,7 +4088,7 @@ Style/NilComparison:
 
 Style/NilLambda:
   Description: 'Prefer `-> {}` to `-> { nil }`.'
-  Enabled: pending
+  Enabled: false
   VersionAdded: '1.3'
 
 Style/NonNilCheck:
@@ -4308,7 +4315,7 @@ Style/RandomWithOffset:
 
 Style/RedundantArgument:
   Description: 'Check for a redundant argument passed to certain methods.'
-  Enabled: pending
+  Enabled: false
   Safe: false
   VersionAdded: '1.4'
   VersionChanged: <<next>>
@@ -4729,7 +4736,7 @@ Style/StructInheritance:
 Style/SwapValues:
   Description: 'This cop enforces the use of shorthand-style swapping of 2 variables.'
   StyleGuide: '#values-swapping'
-  Enabled: pending
+  Enabled: false
   VersionAdded: '1.1'
   SafeAutoCorrect: false
 


### PR DESCRIPTION
# Background
Disable all pending rules - otherwise, it gives a warning that `pending` is not a valid boolean value when running rubocop locally

## Did you make sure to?
### Project Management
- [ ] Review it as needed with the technical team leader?
- [ ] Attach the PR to the Trello card?

### PR
- [x] Assign yourself to the PR
- [x] Add at least one reviewer

### Before-Merge
- [ ] Update the repos dependent on those rules - delete the current cached rubocop.yml, and run `rubocop` again to refresh
- [ ] Validate changes against affected repositories, and if needed, prepare PRs to update repositories according to changes

### Post-Merge
- [ ] Verify that your Trello card was moved to today's release and that it was announced in #releases slack channel
