### PR TITLE
Turn off Style/HashAsLastArrayItem rule

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -3547,7 +3547,7 @@ Style/HashAsLastArrayItem:
     Checks for presence or absence of braces around hash literal as a last
     array item depending on configuration.
   StyleGuide: '#hash-literal-as-last-array-item'
-  Enabled: true
+  Enabled: false
   VersionAdded: '0.88'
   EnforcedStyle: braces
   SupportedStyles:


### PR DESCRIPTION
# Background
Turn off Style/HashAsLastArrayItem rule

## Did you make sure to?
### Project Management
- [ ] Review it as needed with the technical team leader?
- [ ] Attach the PR to the Trello card?

### PR
- [x] Assign yourself to the PR
- [x] Add at least one reviewer

### Before-Merge
- [ ] Update the repos dependent on those rules - delete the current cached rubocop.yml, and run `rubocop` again to refresh
- [ ] Validate changes against affected repositories, and if needed, prepare PRs to update repositories according to changes

### Post-Merge
- [ ] Verify that your Trello card was moved to today's release and that it was announced in #releases slack channel
