### PR TITLE
Clear rubocop warnings

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1269,8 +1269,6 @@ Layout/SpaceBeforeBrackets:
   Description: 'Checks for receiver with a space before the opening brackets.'
   StyleGuide: '#space-in-brackets-access'
   Enabled: false
-  VersionAdded: '<<next>>'
-  Safe: false
   VersionAdded: '1.7'
 
 Layout/SpaceBeforeComma:


### PR DESCRIPTION
# Background
Clear rubocop warnings

```
.rubocop-https---raw-githubusercontent-com-TailorBrands-tailor-rubocop-master-rubocop-yml:1272: `VersionAdded` is concealed by line 1274
Warning: obsolete parameter `ExcludedMethods` (for `Metrics/BlockLength`) found in .rubocop-https---raw-githubusercontent-com-TailorBrands-tailor-rubocop-master-rubocop-yml
`ExcludedMethods` has been renamed to `IgnoredMethods`.
obsolete parameter `ExcludedMethods` (for `Metrics/MethodLength`) found in .rubocop-https---raw-githubusercontent-com-TailorBrands-tailor-rubocop-master-rubocop-yml
`ExcludedMethods` has been renamed to `IgnoredMethods`.
Warning: Layout/SpaceBeforeBrackets does not support Safe parameter.

Supported parameters are:

  - Enabled
 ```

## Did you make sure to?
### Project Management
- [ ] Review it as needed with the technical team leader?
- [ ] Attach the PR to the Trello card?

### PR
- [x] Assign yourself to the PR
- [x] Add at least one reviewer

### Before-Merge
- [ ] Update the repos dependent on those rules - delete the current cached rubocop.yml, and run `rubocop` again to refresh
- [ ] Validate changes against affected repositories, and if needed, prepare PRs to update repositories according to changes

### Post-Merge
- [ ] Verify that your Trello card was moved to today's release and that it was announced in #releases slack channel
