### PR TITLE
Align rubocop.yml with version 1.8.1

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -767,7 +767,7 @@ Layout/FirstMethodParameterLineBreak:
   Enabled: false
   VersionAdded: '0.49'
 
-Layout/FirstParameterIndentation:
+Layout/FirstArgumentIndentation:
   Description: >-
     Checks the indentation of the first parameter in a
     method definition.


### PR DESCRIPTION
# Background
Done using: https://docs.rubocop.org/rubocop/1.7/configuration.html#updating-the-configuration-file

## Did you make sure to?
### Project Management
- [ ] Review it as needed with the technical team leader?
- [ ] Attach the PR to the Trello card?

### PR
- [x] Assign yourself to the PR
- [x] Add at least one reviewer

### Before-Merge
- [ ] Update the repos dependent on those rules - delete the current cached rubocop.yml, and run `rubocop` again to refresh
- [ ] Validate changes against affected repositories, and if needed, prepare PRs to update repositories according to changes

### Post-Merge
- [ ] Verify that your Trello card was moved to today's release and that it was announced in #releases slack channel
