### PR TITLE
Increase threshold for Metrics/ParameterLists to 15 parameters

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -2456,7 +2456,7 @@ Metrics/ParameterLists:
   Enabled: true
   VersionAdded: '0.25'
   VersionChanged: '1.5'
-  Max: 5
+  Max: 15
   CountKeywordArgs: true
   MaxOptionalParameters: 3
 


### PR DESCRIPTION
# Background
Increase threshold for Metrics/ParameterLists to 15 parameters

## Did you make sure to?
### Project Management
- [ ] Review it as needed with the technical team leader?
- [ ] Attach the PR to the Trello card?

### PR
- [x] Assign yourself to the PR
- [x] Add at least one reviewer

### Before-Merge
- [ ] Update the repos dependent on those rules - delete the current cached rubocop.yml, and run `rubocop` again to refresh
- [ ] Validate changes against affected repositories, and if needed, prepare PRs to update repositories according to changes

### Post-Merge
- [ ] Verify that your Trello card was moved to today's release and that it was announced in #releases slack channel
