### PR TITLE
Update rubocop configuration to the latest version

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -207,6 +207,13 @@ Bundler/OrderedGems:
 
 #################### Gemspec ###############################
 
+Gemspec/DateAssignment:
+  Description: 'Checks that `date =` is not used in gemspec file, it is set automatically when the gem is packaged.'
+  Enabled: pending
+  VersionAdded: '1.10'
+  Include:
+    - '**/*.gemspec'
+
 Gemspec/DuplicatedAssignment:
   Description: 'An attribute assignment method calls should be listed only once in a gemspec.'
   Enabled: true
@@ -444,7 +451,6 @@ Layout/DefEndAlignment:
   SupportedStylesAlignWith:
     - start_of_line
     - def
-  AutoCorrect: false
 
 Layout/DotPosition:
   Description: 'Checks the position of the dot in multi-line method calls.'
@@ -612,7 +618,6 @@ Layout/EmptyLinesAroundModuleBody:
 Layout/EndAlignment:
   Description: 'Align ends correctly.'
   Enabled: true
-  Severity: error
   VersionAdded: '0.53'
   # The value `keyword` means that `end` should be aligned with the matching
   # keyword (`if`, `while`, etc.).
@@ -626,7 +631,7 @@ Layout/EndAlignment:
     - keyword
     - variable
     - start_of_line
-  AutoCorrect: false
+  Severity: error
 
 Layout/EndOfLine:
   Description: 'Use Unix-style line endings.'
@@ -767,12 +772,11 @@ Layout/FirstMethodParameterLineBreak:
   Enabled: false
   VersionAdded: '0.49'
 
-Layout/FirstArgumentIndentation:
+Layout/FirstParameterIndentation:
   Description: >-
     Checks the indentation of the first parameter in a
     method definition.
   Enabled: true
-  Severity: error
   VersionAdded: '0.49'
   VersionChanged: '0.77'
   EnforcedStyle: consistent
@@ -1268,7 +1272,7 @@ Layout/SpaceBeforeBlockBraces:
 Layout/SpaceBeforeBrackets:
   Description: 'Checks for receiver with a space before the opening brackets.'
   StyleGuide: '#space-in-brackets-access'
-  Enabled: false
+  Enabled: pending
   VersionAdded: '1.7'
 
 Layout/SpaceBeforeComma:
@@ -1451,7 +1455,7 @@ Layout/TrailingWhitespace:
 
 Lint/AmbiguousAssignment:
   Description: 'Checks for mistyped shorthand assignments.'
-  Enabled: false
+  Enabled: pending
   VersionAdded: '1.7'
 
 Lint/AmbiguousBlockAssociation:
@@ -1542,11 +1546,7 @@ Lint/Debugger:
   Enabled: true
   Severity: error
   VersionAdded: '0.14'
-  VersionChanged: '0.49'
-  DebuggerReceivers:
-    - binding
-    - Kernel
-    - Pry
+  VersionChanged: '1.10'
   DebuggerMethods:
     - debugger
     - byebug
@@ -1568,7 +1568,7 @@ Lint/DeprecatedClassMethods:
 
 Lint/DeprecatedConstants:
   Description: 'Checks for deprecated constants.'
-  Enabled: false
+  Enabled: pending
   VersionAdded: '1.8'
   # You can configure deprecated constants.
   # If there is an alternative method, you can set alternative value as `Alternative`.
@@ -1609,7 +1609,7 @@ Lint/DisjunctiveAssignmentInConstructor:
 
 Lint/DuplicateBranch:
   Description: Checks that there are no repeated bodies within `if/unless`, `case-when` and `rescue` constructs.
-  Enabled: false
+  Enabled: pending
   VersionAdded: '1.3'
   VersionChanged: '1.7'
   IgnoreLiteralBranches: false
@@ -1641,7 +1641,7 @@ Lint/DuplicateMethods:
 
 Lint/DuplicateRegexpCharacterClassElement:
   Description: 'Checks for duplicate elements in Regexp character classes.'
-  Enabled: false
+  Enabled: pending
   VersionAdded: '1.1'
 
 Lint/DuplicateRequire:
@@ -1669,7 +1669,7 @@ Lint/ElseLayout:
 
 Lint/EmptyBlock:
   Description: 'This cop checks for blocks without a body.'
-  Enabled: false
+  Enabled: pending
   VersionAdded: '1.1'
   VersionChanged: '1.3'
   AllowComments: true
@@ -1677,7 +1677,7 @@ Lint/EmptyBlock:
 
 Lint/EmptyClass:
   Description: 'Checks for classes and metaclasses without a body.'
-  Enabled: false
+  Enabled: pending
   VersionAdded: '1.3'
   AllowComments: false
 
@@ -1821,7 +1821,7 @@ Lint/InterpolationCheck:
 
 Lint/LambdaWithoutLiteralBlock:
   Description: 'Checks uses of lambda without a literal block.'
-  Enabled: false
+  Enabled: pending
   VersionAdded: '1.8'
 
 Lint/LiteralAsCondition:
@@ -1906,7 +1906,7 @@ Lint/NextWithoutAccumulator:
 
 Lint/NoReturnInBeginEndBlocks:
   Description: 'Do not `return` inside `begin..end` blocks in assignment contexts.'
-  Enabled: false
+  Enabled: pending
   VersionAdded: '1.2'
 
 Lint/NonDeterministicRequireOrder:
@@ -1932,6 +1932,17 @@ Lint/NumberConversion:
   IgnoredClasses:
     - Time
     - DateTime
+
+Lint/NumberedParameterAssignment:
+  Description: 'Checks for uses of numbered parameter assignment.'
+  Enabled: pending
+  VersionAdded: '1.9'
+
+Lint/OrAssignmentToConstant:
+  Description: 'Checks unintended or-assignment to constant.'
+  Enabled: pending
+  Safe: false
+  VersionAdded: '1.9'
 
 Lint/OrderedMagicComments:
   Description: 'Checks the proper ordering of magic comments and whether a magic comment is not placed before a shebang.'
@@ -2005,7 +2016,7 @@ Lint/RedundantCopEnableDirective:
 
 Lint/RedundantDirGlobSort:
   Description: 'Checks for redundant `sort` method to `Dir.glob` and `Dir[]`.'
-  Enabled: false
+  Enabled: pending
   VersionAdded: '1.8'
 
 Lint/RedundantRequireStatement:
@@ -2182,17 +2193,25 @@ Lint/SuppressedException:
   Enabled: true
   Severity: error
   VersionAdded: '0.9'
-  VersionChanged: '0.81'
+  VersionChanged: '1.12'
+
+Lint/SymbolConversion:
+  Description: 'Checks for unnecessary symbol conversions.'
+  Enabled: pending
+  VersionAdded: '1.9'
+  EnforcedStyle: strict
+  SupportedStyles:
+    - strict
+    - consistent
 
 Lint/Syntax:
-  Description: 'Checks syntax error.'
+  Description: 'Checks for syntax errors.'
   Enabled: true
   VersionAdded: '0.9'
 
-
 Lint/ToEnumArguments:
   Description: 'This cop ensures that `to_enum`/`enum_for`, called for the current method, has correct arguments.'
-  Enabled: false
+  Enabled: pending
   VersionAdded: '1.1'
 
 Lint/ToJSON:
@@ -2211,6 +2230,11 @@ Lint/TrailingCommaInAttributeDeclaration:
   Enabled: true
   VersionAdded: '0.90'
 
+Lint/TripleQuotes:
+  Description: 'Checks for useless triple quote constructs.'
+  Enabled: pending
+  VersionAdded: '1.9'
+
 Lint/UnderscorePrefixedVariableName:
   Description: 'Do not use prefix `_` for a variable that is used.'
   Enabled: true
@@ -2220,7 +2244,7 @@ Lint/UnderscorePrefixedVariableName:
 
 Lint/UnexpectedBlockArity:
   Description: 'Looks for blocks that have fewer arguments that the calling method expects.'
-  Enabled: false
+  Enabled: pending
   Safe: false
   VersionAdded: '1.5'
   Methods:
@@ -2243,7 +2267,7 @@ Lint/UnifiedInteger:
 
 Lint/UnmodifiedReduceAccumulator:
   Description: Checks for `reduce` or `inject` blocks that do not update the accumulator each iteration.
-  Enabled: false
+  Enabled: pending
   VersionAdded: '1.1'
   VersionChanged: '1.5'
 
@@ -2380,7 +2404,6 @@ Metrics/BlockLength:
   CountComments: false  # count full line comments?
   Max: 80
   CountAsOne: []
-  ExcludedMethods: [] # deprecated, retained for backwards compatibility
   IgnoredMethods:
     # By default, exclude the `#refine` method, as it tends to have larger
     # associated blocks.
@@ -2435,7 +2458,6 @@ Metrics/MethodLength:
   CountComments: false  # count full line comments?
   Max: 80
   CountAsOne: []
-  ExcludedMethods: [] # deprecated, retained for backwards compatibility
   IgnoredMethods: []
   Exclude:
     # Migrations are one time thing
@@ -2642,6 +2664,7 @@ Naming/MemoizedInstanceVariableName:
     - disallowed
     - required
     - optional
+  Safe: false
 
 Naming/MethodName:
   Description: 'Use the configured style when naming methods.'
@@ -2863,7 +2886,7 @@ Style/AndOr:
 Style/ArgumentsForwarding:
   Description: 'Use arguments forwarding.'
   StyleGuide: '#arguments-forwarding'
-  Enabled: false
+  Enabled: pending
   AllowOnlyRestArgument: true
   VersionAdded: '1.1'
 
@@ -3159,7 +3182,7 @@ Style/ClassVars:
 
 Style/CollectionCompact:
   Description: 'Use `{Array,Hash}#{compact,compact!}` instead of custom logic to reject nils.'
-  Enabled: false
+  Enabled: pending
   Safe: false
   VersionAdded: '1.2'
   VersionChanged: '1.3'
@@ -3284,6 +3307,8 @@ Style/ConstantVisibility:
     visibility declarations.
   Enabled: false
   VersionAdded: '0.66'
+  VersionChanged: '1.10'
+  IgnoreModules: false
 
 # Checks that you have put a copyright in a comment before any code.
 #
@@ -3340,13 +3365,15 @@ Style/DisableCopsWithinSourceCodeDirective:
     Forbids disabling/enabling cops within source code.
   Enabled: false
   VersionAdded: '0.82'
+  VersionChanged: '1.9'
+  AllowedCops: []
 
 Style/DocumentDynamicEvalDefinition:
   Description: >-
     When using `class_eval` (or other `eval`) with string interpolation,
     add a comment block showing its appearance if interpolated.
   StyleGuide: '#eval-comment-docs'
-  Enabled: false
+  Enabled: pending
   VersionAdded: '1.1'
   VersionChanged: '1.3'
 
@@ -3354,6 +3381,7 @@ Style/Documentation:
   Description: 'Document classes and non-namespace modules.'
   Enabled: false
   VersionAdded: '0.9'
+  AllowedConstants: []
   Exclude:
     - 'spec/**/*'
     - 'test/**/*'
@@ -3471,7 +3499,7 @@ Style/EndBlock:
 Style/EndlessMethod:
   Description: 'Avoid the use of multi-lined endless method definitions.'
   StyleGuide: '#endless-methods'
-  Enabled: false
+  Enabled: pending
   VersionAdded: '1.8'
   EnforcedStyle: allow_single_line
   SupportedStyles:
@@ -3505,9 +3533,8 @@ Style/ExplicitBlockArgument:
     that just passes its arguments to another block.
   StyleGuide: '#block-argument'
   Enabled: true
-  # May change the yielding arity.
-  Safe: false
   VersionAdded: '0.89'
+  VersionChanged: '1.8'
 
 Style/ExponentialNotation:
   Description: 'When using exponential notation, favor a mantissa between 1 (inclusive) and 10 (exclusive).'
@@ -3527,7 +3554,8 @@ Style/FloatDivision:
   Severity: error
   Reference: 'https://blog.rubystyle.guide/ruby/2019/06/21/float-division.html'
   VersionAdded: '0.72'
-  VersionChanged: '1.6'
+  VersionChanged: '1.9'
+  Safe: false
   EnforcedStyle: single_coerce
   SupportedStyles:
     - left_coerce
@@ -3578,6 +3606,7 @@ Style/FormatStringToken:
   MaxUnannotatedPlaceholdersAllowed: 1
   VersionAdded: '0.49'
   VersionChanged: '1.0'
+  IgnoredMethods: []
 
 Style/FrozenStringLiteralComment:
   Description: >-
@@ -3642,6 +3671,13 @@ Style/HashAsLastArrayItem:
     - braces
     - no_braces
 
+Style/HashConversion:
+  Description: 'Avoid Hash[] in favor of ary.to_h or literal hashes.'
+  Enabled: pending
+  VersionAdded: '1.10'
+  VersionChanged: '1.11'
+  AllowSplatArgument: true
+
 Style/HashEachMethods:
   Description: 'Use Hash#each_key and Hash#each_value.'
   StyleGuide: '#hash-each'
@@ -3653,7 +3689,7 @@ Style/HashExcept:
   Description: >-
     Checks for usages of `Hash#reject`, `Hash#select`, and `Hash#filter` methods
     that can be replaced with `Hash#except` method.
-  Enabled: false
+  Enabled: pending
   VersionAdded: '1.7'
 
 Style/HashLikeCase:
@@ -3868,6 +3904,7 @@ Style/MethodCallWithArgsParentheses:
   AllowParenthesesInMultilineCall: false
   AllowParenthesesInChaining: false
   AllowParenthesesInCamelCaseMethod: false
+  AllowParenthesesInStringInterpolation: false
   EnforcedStyle: require_parentheses
   SupportedStyles:
     - require_parentheses
@@ -4079,7 +4116,7 @@ Style/NegatedIfElseCondition:
   Description: >-
     This cop checks for uses of `if-else` and ternary operators with a negated condition
     which can be simplified by inverting condition and swapping branches.
-  Enabled: false
+  Enabled: pending
   VersionAdded: '1.2'
 
 Style/NegatedUnless:
@@ -4178,7 +4215,7 @@ Style/NilComparison:
 
 Style/NilLambda:
   Description: 'Prefer `-> {}` to `-> { nil }`.'
-  Enabled: false
+  Enabled: pending
   VersionAdded: '1.3'
 
 Style/NonNilCheck:
@@ -4405,7 +4442,7 @@ Style/RandomWithOffset:
 
 Style/RedundantArgument:
   Description: 'Check for a redundant argument passed to certain methods.'
-  Enabled: false
+  Enabled: pending
   Safe: false
   VersionAdded: '1.4'
   VersionChanged: '1.7'
@@ -4752,6 +4789,13 @@ Style/StderrPuts:
   Severity: error
   VersionAdded: '0.51'
 
+Style/StringChars:
+  Description: 'Checks for uses of `String#split` with empty string or regexp literal argument.'
+  StyleGuide: '#string-chars'
+  Enabled: pending
+  Safe: false
+  VersionAdded: '1.12'
+
 Style/StringConcatenation:
   Description: 'Checks for places where string concatenation can be replaced with string interpolation.'
   StyleGuide: '#string-interpolation'
@@ -4826,7 +4870,7 @@ Style/StructInheritance:
 Style/SwapValues:
   Description: 'This cop enforces the use of shorthand-style swapping of 2 variables.'
   StyleGuide: '#values-swapping'
-  Enabled: false
+  Enabled: pending
   VersionAdded: '1.1'
   SafeAutoCorrect: false
 
@@ -4855,6 +4899,7 @@ Style/SymbolProc:
   Safe: false
   VersionAdded: '0.26'
   VersionChanged: '1.5'
+  AllowMethodsWithArguments: false
   # A list of method names to be ignored by the check.
   # The names should be fairly unique, otherwise you'll end up ignoring lots of code.
   IgnoredMethods:
@@ -5014,6 +5059,16 @@ Style/UnlessElse:
   Enabled: true
   Severity: error
   VersionAdded: '0.9'
+
+Style/UnlessLogicalOperators:
+  Description: >-
+    Checks for use of logical operators in an unless condition.
+  Enabled: false
+  VersionAdded: '1.11'
+  EnforcedStyle: forbid_mixed_logical_operators
+  SupportedStyles:
+    - forbid_mixed_logical_operators
+    - forbid_logical_operators
 
 Style/UnpackFirst:
   Description: >-


### PR DESCRIPTION
# Background
Update rubocop configuration to the latest version, this change is done in order to clear the current warnings we have during the lint run process in GitHub workflow:

```
`Layout/FirstArgumentIndentation` is concealed by line 770
  Warning: obsolete parameter `ExcludedMethods` (for `Metrics/BlockLength`) found in .rubocop-https---raw-githubusercontent-com-TailorBrands-tailor-rubocop-master-rubocop-yml
  `ExcludedMethods` has been renamed to `IgnoredMethods`.
  obsolete parameter `ExcludedMethods` (for `Metrics/MethodLength`) found in .rubocop-https---raw-githubusercontent-com-TailorBrands-tailor-rubocop-master-rubocop-yml
  `ExcludedMethods` has been renamed to `IgnoredMethods`.
  Warning: Style/ExplicitBlockArgument does not support Safe parameter.
  
  Supported parameters are:
  
    - Enabled
  Error: configuration for Syntax cop found in .rubocop-https---raw-githubusercontent-com-TailorBrands-tailor-rubocop-master-rubocop-yml
  It's not possible to disable this cop.
```

## Did you make sure to?
### Project Management
- [ ] Review it as needed with the technical team leader?
- [ ] Attach the PR to the Trello card?

### PR
- [x] Assign yourself to the PR
- [x] Add at least one reviewer

### Before-Merge
- [ ] Update the repos dependent on those rules - delete the current cached rubocop.yml, and run `rubocop` again to refresh
- [ ] Validate changes against affected repositories, and if needed, prepare PRs to update repositories according to changes

### Post-Merge
- [ ] Verify that your Trello card was moved to today's release and that it was announced in #releases slack channel
