### PR TITLE
Align Rubocop configuration files with updated definitions

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -133,7 +133,7 @@ AllCops:
   # What MRI version of the Ruby interpreter is the inspected code intended to
   # run on? (If there is more than one, set this to the lowest version.)
   # If a value is specified for TargetRubyVersion then it is used. Acceptable
-  # values are specificed as a float (i.e. 2.5); the teeny version of Ruby
+  # values are specificed as a float (i.e. 3.0); the teeny version of Ruby
   # should not be included. If the project specifies a Ruby version in the
   # .tool-versions or .ruby-version files, Gemfile or gems.rb file, RuboCop will
   # try to determine the desired version of Ruby by inspecting the
@@ -141,7 +141,7 @@ AllCops:
   # or gems.locked file. (Although the Ruby version is specified in the Gemfile
   # or gems.rb file, RuboCop reads the final value from the lock file.) If the
   # Ruby version is still unresolved, RuboCop will use the oldest officially
-  # supported Ruby version (currently Ruby 2.4).
+  # supported Ruby version (currently Ruby 2.5).
   TargetRubyVersion: ~
   # Determines if a notification for extension libraries should be shown when
   # rubocop is run. Keys are the name of the extension, and values are an array
@@ -177,6 +177,20 @@ Bundler/GemComment:
     - '**/gems.rb'
   IgnoredGems: []
   OnlyFor: []
+
+Bundler/GemVersion:
+  Description: 'Requires or forbids specifying gem versions.'
+  Enabled: false
+  VersionAdded: '1.14'
+  EnforcedStyle: 'required'
+  SupportedStyles:
+    - 'required'
+    - 'forbidden'
+  Include:
+    - '**/*.gemfile'
+    - '**/Gemfile'
+    - '**/gems.rb'
+  AllowedGems: []
 
 Bundler/InsecureProtocolSource:
   Description: >-
@@ -1159,11 +1173,24 @@ Layout/ParameterAlignment:
   # But it can be overridden by setting this parameter
   IndentationWidth: ~
 
+Layout/RedundantLineBreak:
+  Description: >-
+    Do not break up an expression into multiple lines when it fits
+    on a single line.
+  Enabled: false
+  InspectBlocks: false
+  VersionAdded: '1.13'
+
 Layout/RescueEnsureAlignment:
   Description: 'Align rescues and ensures correctly.'
   Enabled: true
   Severity: error
   VersionAdded: '0.49'
+
+Layout/SingleLineBlockChain:
+  Description: 'Put method call on a separate line if chained to a single line block.'
+  Enabled: false
+  VersionAdded: '1.14'
 
 Layout/SpaceAfterColon:
   Description: 'Use spaces after colons.'
@@ -1466,6 +1493,8 @@ Lint/AmbiguousBlockAssociation:
   Enabled: true
   Severity: error
   VersionAdded: '0.48'
+  VersionChanged: '1.13'
+  IgnoredMethods: []
 
 Lint/AmbiguousOperator:
   Description: >-
@@ -1671,7 +1700,7 @@ Lint/EmptyBlock:
   Description: 'This cop checks for blocks without a body.'
   Enabled: pending
   VersionAdded: '1.1'
-  VersionChanged: '1.3'
+  VersionChanged: '<<next>>'
   AllowComments: true
   AllowEmptyLambdas: true
 
@@ -2192,6 +2221,8 @@ Lint/SuppressedException:
   StyleGuide: '#dont-hide-exceptions'
   Enabled: true
   Severity: error
+  AllowComments: true
+  AllowNil: true
   VersionAdded: '0.9'
   VersionChanged: '1.12'
 
@@ -2495,7 +2526,9 @@ Metrics/PerceivedComplexity:
 ################## Migration #############################
 
 Migration/DepartmentName:
-  Description: 'Check that cop names in rubocop:disable (etc) comments are given with department name.'
+  Description: >-
+    Check that cop names in rubocop:disable (etc) comments are
+    given with department name.
   Enabled: false
   VersionAdded: '0.75'
 
@@ -2568,9 +2601,7 @@ Naming/FileName:
   VersionAdded: '0.50'
   # Camel case file names listed in `AllCops:Include` and all file names listed
   # in `AllCops:Exclude` are excluded by default. Add extra excludes here.
-  Exclude: [
-    "Gemfile.ruby"
-  ]
+  Exclude: []
   # When `true`, requires that each source file should define a class or module
   # with a name which matches the file name (converted to ... case).
   # It further expects it to be nested inside modules which match the names
@@ -2969,10 +3000,10 @@ Style/BlockDelimiters:
     Prefer {...} over do...end for single-line blocks.
   StyleGuide: '#single-line-blocks'
   Enabled: true
-  Severity: error
-  EnforcedStyle: braces_for_chaining
   VersionAdded: '0.30'
   VersionChanged: '0.35'
+  EnforcedStyle: braces_for_chaining
+  Severity: error
   SupportedStyles:
     # The `line_count_based` style enforces braces around single line blocks and
     # do..end around multi-line blocks.
@@ -3673,6 +3704,7 @@ Style/HashAsLastArrayItem:
 
 Style/HashConversion:
   Description: 'Avoid Hash[] in favor of ary.to_h or literal hashes.'
+  StyleGuide: '#avoid-hash-constructor'
   Enabled: pending
   VersionAdded: '1.10'
   VersionChanged: '1.11'
@@ -3774,6 +3806,14 @@ Style/IfUnlessModifierOfIfUnless:
   Severity: error
   VersionAdded: '0.39'
   VersionChanged: '0.87'
+
+Style/IfWithBooleanLiteralBranches:
+  Description: 'Checks for redundant `if` with boolean literal branches.'
+  Enabled: pending
+  VersionAdded: '1.9'
+  SafeAutoCorrect: false
+  AllowedMethods:
+    - nonzero?
 
 Style/IfWithSemicolon:
   Description: 'Do not use if x; .... Use the ternary operator instead.'
@@ -4217,6 +4257,7 @@ Style/NilLambda:
   Description: 'Prefer `-> {}` to `-> { nil }`.'
   Enabled: pending
   VersionAdded: '1.3'
+  VersionChanged: '<<next>>'
 
 Style/NonNilCheck:
   Description: 'Checks for redundant nil checks.'
@@ -4919,6 +4960,12 @@ Style/TernaryParentheses:
     - require_parentheses_when_complex
   AllowSafeAssignment: true
 
+Style/TopLevelMethodDefinition:
+  Description: 'This cop looks for top-level method definitions.'
+  StyleGuide: '#top-level-methods'
+  Enabled: false
+  VersionAdded: '<<next>>'
+
 Style/TrailingBodyOnClass:
   Description: 'Class body goes below class statement.'
   Enabled: true
@@ -4939,8 +4986,8 @@ Style/TrailingBodyOnModule:
 
 Style/TrailingCommaInArguments:
   Description: 'Checks for trailing comma in argument lists.'
-  Enabled: false
   StyleGuide: '#no-trailing-params-comma'
+  Enabled: false
   VersionAdded: '0.36'
   # If `comma`, the cop requires a comma after the last argument, but only for
   # parenthesized method calls where each argument is on its own line.
@@ -4954,14 +5001,14 @@ Style/TrailingCommaInArguments:
 
 Style/TrailingCommaInArrayLiteral:
   Description: 'Checks for trailing comma in array literals.'
-  Enabled: false
   StyleGuide: '#no-trailing-array-commas'
+  Enabled: false
   VersionAdded: '0.53'
   # If `comma`, the cop requires a comma after the last item in an array,
   # but only when each item is on its own line.
   # If `consistent_comma`, the cop requires a comma after the last item of all
-  # non-empty array literals.
-  EnforcedStyleForMultiline:  comma
+  # non-empty, multiline array literals.
+  EnforcedStyleForMultiline: comma
   SupportedStylesForMultiline:
     - comma
     - consistent_comma
@@ -5011,7 +5058,7 @@ Style/TrivialAccessors:
   Enabled: true
   Severity: error
   VersionAdded: '0.9'
-  VersionChanged: '0.77'
+  VersionChanged: '<<next>>'
   # When set to `false` the cop will suggest the use of accessor methods
   # in situations like:
   #


### PR DESCRIPTION
# Background
Align Rubocop configuration files with updated definitions

## Did you make sure to?
### Project Management
- [ ] Review it as needed with the technical team leader?
- [ ] Attach the PR to the Trello card?

### PR
- [x] Assign yourself to the PR
- [ ] Add at least one reviewer

### Before-Merge
- [ ] Update the repos dependent on those rules - delete the current cached rubocop.yml, and run `rubocop` again to refresh
- [ ] Validate changes against affected repositories, and if needed, prepare PRs to update repositories according to changes

### Post-Merge
- [ ] Verify that your Trello card was moved to today's release and that it was announced in #releases slack channel
