### PR TITLE
Remove redundant rule

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -2186,11 +2186,6 @@ Lint/RequireParentheses:
   Severity: error
   VersionAdded: '0.18'
 
-Lint/RequireRelativeSelfPath:
-  Description: 'Checks for uses a file requiring itself with `require_relative`.'
-  Enabled: pending
-  VersionAdded: '<<next>>'
-
 Lint/RescueException:
   Description: 'Avoid rescuing the Exception class.'
   StyleGuide: '#no-blind-rescues'


### PR DESCRIPTION
# Background
Remove redundant rule -

```
  Error: unrecognized cop or department Lint/RequireRelativeSelfPath found in .rubocop-https---raw-githubusercontent-com-TailorBrands-tailor-rubocop-master-rubocop-yml
  Did you mean `Lint/RequireParentheses`?
```

## Did you make sure to?
### Project Management
- [ ] Review it as needed with the technical team leader?
- [ ] Attach the PR to the Trello card?

### PR
- [x] Assign yourself to the PR
- [x] Add at least one reviewer

### Before-Merge
- [ ] Update the repos dependent on those rules - delete the current cached rubocop.yml, and run `rubocop` again to refresh
- [ ] Validate changes against affected repositories, and if needed, prepare PRs to update repositories according to changes

### Post-Merge
- [ ] Verify that your Trello card was moved to today's release and that it was announced in #releases slack channel
