### PR TITLE
Remove wrong parameter from Lint/InheritException cop

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1940,7 +1940,6 @@ Lint/InheritException:
   Enabled: true
   Severity: error
   VersionAdded: '0.41'
-  VersionChanged: '<<next>>'
   # The default base class in favour of `Exception`.
   EnforcedStyle: runtime_error
   SupportedStyles:


### PR DESCRIPTION
# Background
Fix the next lint warning: 

```
Warning: Lint/InheritException does not support VersionChanged parameter.
  
  Supported parameters are:
  
    - Enabled
    - EnforcedStyle
    - SupportedStyles
  Warning: Lint/InheritException does not support VersionChanged parameter.
```

## Did you make sure to?
### Project Management
- [ ] Review it as needed with the technical team leader?
- [ ] Attach the PR to the Trello card?

### PR
- [x] Assign yourself to the PR
- [x] Add at least one reviewer

### Before-Merge
- [ ] Update the repos dependent on those rules - delete the current cached rubocop.yml, and run `rubocop` again to refresh
- [ ] Validate changes against affected repositories, and if needed, prepare PRs to update repositories according to changes

### Post-Merge
- [ ] Verify that your Trello card was moved to today's release and that it was announced in #releases slack channel
