### PR TITLE
Align Rubocop configuration to new Rubocop version

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -156,6 +156,8 @@ AllCops:
     rubocop-sequel: [sequel]
     rubocop-rake: [rake]
     rubocop-graphql: [graphql]
+  # Enable/Disable checking the methods extended by Active Support.
+  ActiveSupportExtensionsEnabled: false
 
 #################### Bundler ###############################
 
@@ -164,6 +166,7 @@ Bundler/DuplicatedGem:
   Enabled: true
   Severity: error
   VersionAdded: '0.46'
+  VersionChanged: '1.40'
   Include:
     - '**/*.gemfile'
     - '**/Gemfile'
@@ -215,7 +218,9 @@ Bundler/InsecureProtocolSource:
     because HTTP requests are insecure. Please change your source to
     'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
   Enabled: true
+  Severity: warning
   VersionAdded: '0.50'
+  VersionChanged: '1.40'
   AllowHttpProtocol: true
   Include:
     - '**/*.gemfile'
@@ -239,13 +244,6 @@ Bundler/OrderedGems:
 
 #################### Gemspec ###############################
 
-Gemspec/DeprecatedAttributeAssignment:
-  Description: Checks that deprecated attribute assignments are not set in a gemspec file.
-  Enabled: pending
-  VersionAdded: '1.30'
-  Include:
-    - '**/*.gemspec'
-
 Gemspec/DependencyVersion:
   Description: 'Requires or forbids specifying gem dependency versions.'
   Enabled: false
@@ -258,11 +256,36 @@ Gemspec/DependencyVersion:
     - '**/*.gemspec'
   AllowedGems: []
 
+Gemspec/DeprecatedAttributeAssignment:
+  Description: Checks that deprecated attribute assignments are not set in a gemspec file.
+  Enabled: pending
+  Severity: warning
+  VersionAdded: '1.30'
+  VersionChanged: '1.40'
+  Include:
+    - '**/*.gemspec'
+
+Gemspec/DevelopmentDependencies:
+  Description: Checks that development dependencies are specified in Gemfile rather than gemspec.
+  Enabled: pending
+  VersionAdded: '1.44'
+  EnforcedStyle: Gemfile
+  SupportedStyles:
+    - Gemfile
+    - gems.rb
+    - gemspec
+  AllowedGems: []
+  Include:
+    - '**/*.gemspec'
+    - '**/Gemfile'
+    - '**/gems.rb'
+
 Gemspec/DuplicatedAssignment:
   Description: 'An attribute assignment method calls should be listed only once in a gemspec.'
   Enabled: true
   Severity: error
   VersionAdded: '0.52'
+  VersionChanged: '1.40'
   Include:
     - '**/*.gemspec'
 
@@ -279,9 +302,11 @@ Gemspec/OrderedDependencies:
     - '**/*.gemspec'
 
 Gemspec/RequireMFA:
-  Description: 'Checks that the gemspec has metadata to require MFA from RubyGems.'
+  Description: 'Checks that the gemspec has metadata to require Multi-Factor Authentication from RubyGems.'
   Enabled: pending
+  Severity: warning
   VersionAdded: '1.23'
+  VersionChanged: '1.40'
   Reference:
     - https://guides.rubygems.org/mfa-requirement-opt-in/
   Include:
@@ -292,7 +317,7 @@ Gemspec/RequiredRubyVersion:
   Enabled: true
   Severity: error
   VersionAdded: '0.52'
-  VersionChanged: '1.22'
+  VersionChanged: '1.40'
   Include:
     - '**/*.gemspec'
 
@@ -302,6 +327,7 @@ Gemspec/RubyVersionGlobalsUsage:
   Enabled: true
   Severity: error
   VersionAdded: '0.72'
+  VersionChanged: '1.40'
   Include:
     - '**/*.gemspec'
 
@@ -387,7 +413,7 @@ Layout/AssignmentIndentation:
     right-hand-side of a multi-line assignment.
   Enabled: true
   VersionAdded: '0.49'
-  VersionChanged: '0.77'
+  VersionChanged: '1.45'
   # By default the indentation width from `Layout/IndentationWidth` is used,
   # but it can be overridden by setting this parameter.
   IndentationWidth: ~
@@ -781,6 +807,7 @@ Layout/FirstArrayElementLineBreak:
     multi-line array.
   Enabled: false
   VersionAdded: '0.49'
+  AllowMultilineFinalElement: false
 
 Layout/FirstHashElementIndentation:
   Description: 'Checks the indentation of the first key in a hash literal.'
@@ -814,6 +841,7 @@ Layout/FirstHashElementLineBreak:
     multi-line hash.
   Enabled: false
   VersionAdded: '0.49'
+  AllowMultilineFinalElement: false
 
 Layout/FirstMethodArgumentLineBreak:
   Description: >-
@@ -821,6 +849,7 @@ Layout/FirstMethodArgumentLineBreak:
     multi-line method call.
   Enabled: false
   VersionAdded: '0.49'
+  AllowMultilineFinalElement: false
 
 Layout/FirstMethodParameterLineBreak:
   Description: >-
@@ -828,6 +857,7 @@ Layout/FirstMethodParameterLineBreak:
     multi-line method parameter definition.
   Enabled: false
   VersionAdded: '0.49'
+  AllowMultilineFinalElement: false
 
 Layout/FirstParameterIndentation:
   Description: >-
@@ -932,7 +962,7 @@ Layout/HeredocArgumentClosingParenthesis:
   VersionAdded: '0.68'
 
 Layout/HeredocIndentation:
-  Description: 'This cop checks the indentation of the here document bodies.'
+  Description: 'Checks the indentation of the here document bodies.'
   StyleGuide: '#squiggly-heredocs'
   Enabled: true
   Severity: error
@@ -967,7 +997,7 @@ Layout/IndentationStyle:
   VersionChanged: '0.82'
   # By default the indentation width from `Layout/IndentationWidth` is used,
   # but it can be overridden by setting this parameter.
-  # It is used during auto-correction to determine how many spaces should
+  # It is used during autocorrection to determine how many spaces should
   # replace each tab.
   IndentationWidth: ~
   EnforcedStyle: spaces
@@ -984,7 +1014,6 @@ Layout/IndentationWidth:
   # Number of spaces for each indentation level.
   Width: 2
   AllowedPatterns: []
-  IgnoredPatterns: [] # deprecated
 
 Layout/InitialIndentation:
   Description: >-
@@ -1009,6 +1038,29 @@ Layout/LeadingEmptyLines:
   Severity: error
   VersionAdded: '0.57'
   VersionChanged: '0.77'
+
+Layout/LineContinuationLeadingSpace:
+  Description: >-
+    Use trailing spaces instead of leading spaces in strings
+    broken over multiple lines (by a backslash).
+  Enabled: pending
+  VersionAdded: '1.31'
+  VersionChanged: '1.45'
+  EnforcedStyle: trailing
+  SupportedStyles:
+    - leading
+    - trailing
+
+Layout/LineContinuationSpacing:
+  Description: 'Checks the spacing in front of backslash in line continuations.'
+  Enabled: pending
+  AutoCorrect: true
+  SafeAutoCorrect: true
+  VersionAdded: '1.31'
+  EnforcedStyle: space
+  SupportedStyles:
+    - space
+    - no_space
 
 Layout/LineEndStringConcatenationIndentation:
   Description: >-
@@ -1043,15 +1095,15 @@ Layout/LineLength:
   # The IgnoreCopDirectives option causes the LineLength rule to ignore cop
   # directives like '# rubocop: enable ...' when calculating a line's length.
   IgnoreCopDirectives: true
-  # The IgnoredPatterns option is a list of !ruby/regexp and/or string
+  # The AllowedPatterns option is a list of !ruby/regexp and/or string
   # elements. Strings will be converted to Regexp objects. A line that matches
   # any regular expression listed in this option will be ignored by LineLength.
-  IgnoredPatterns: [
-      'http://',
-      'https://',
-      'data = ',
-      'if ',
-      'unless '
+  AllowedPatterns: [
+    'http://',
+    'https://',
+    'data = ',
+    'if ',
+    'unless '
   ]
 
 Layout/MultilineArrayBraceLayout:
@@ -1077,6 +1129,7 @@ Layout/MultilineArrayLineBreaks:
     starts on a separate line.
   Enabled: false
   VersionAdded: '0.67'
+  AllowMultilineFinalElement: false
 
 Layout/MultilineAssignmentLayout:
   Description: 'Check for a newline after the assignment operator in multi-line assignments.'
@@ -1129,6 +1182,7 @@ Layout/MultilineHashKeyLineBreaks:
     starts on a separate line.
   Enabled: false
   VersionAdded: '0.67'
+  AllowMultilineFinalElement: false
 
 Layout/MultilineMethodArgumentLineBreaks:
   Description: >-
@@ -1136,6 +1190,7 @@ Layout/MultilineMethodArgumentLineBreaks:
     starts on a separate line.
   Enabled: false
   VersionAdded: '0.67'
+  AllowMultilineFinalElement: false
 
 Layout/MultilineMethodCallBraceLayout:
   Description: >-
@@ -1186,6 +1241,14 @@ Layout/MultilineMethodDefinitionBraceLayout:
     - symmetrical
     - new_line
     - same_line
+
+Layout/MultilineMethodParameterLineBreaks:
+  Description: >-
+    Checks that each parameter in a multi-line method definition
+    starts on a separate line.
+  Enabled: false
+  VersionAdded: '1.32'
+  AllowMultilineFinalElement: false
 
 Layout/MultilineOperationIndentation:
   Description: >-
@@ -1556,7 +1619,8 @@ Lint/AmbiguousBlockAssociation:
   Severity: error
   VersionAdded: '0.48'
   VersionChanged: '1.13'
-  IgnoredMethods: []
+  AllowedMethods: []
+  AllowedPatterns: []
 
 Lint/AmbiguousOperator:
   Description: >-
@@ -1597,7 +1661,9 @@ Lint/AssignmentInCondition:
   StyleGuide: '#safe-assignment-in-condition'
   Enabled: true
   Severity: error
+  SafeAutoCorrect: false
   VersionAdded: '0.9'
+  VersionChanged: '1.45'
   AllowSafeAssignment: true
 
 Lint/BigDecimalNew:
@@ -1607,7 +1673,7 @@ Lint/BigDecimalNew:
   VersionAdded: '0.53'
 
 Lint/BinaryOperatorWithIdenticalOperands:
-  Description: 'This cop checks for places where binary operator has identical operands.'
+  Description: 'Checks for places where binary operator has identical operands.'
   Enabled: true
   Safe: false
   VersionAdded: '0.89'
@@ -1638,6 +1704,11 @@ Lint/ConstantDefinitionInBlock:
   AllowedMethods:
     - enums
 
+Lint/ConstantOverwrittenInRescue:
+  Description: 'Checks for overwriting an exception with an exception result by use `rescue =>`.'
+  Enabled: pending
+  VersionAdded: '1.31'
+
 Lint/ConstantResolution:
   Description: 'Check that constants are fully qualified with `::`.'
   Enabled: false
@@ -1652,12 +1723,13 @@ Lint/Debugger:
   Enabled: true
   Severity: error
   VersionAdded: '0.14'
-  VersionChanged: '1.10'
+  VersionChanged: '<<next>>'
   DebuggerMethods:
     # Groups are available so that a specific group can be disabled in
     # a user's configuration, but are otherwise not significant.
     Kernel:
       - binding.irb
+      - Kernel.binding.irb
     Byebug:
       - byebug
       - remote_byebug
@@ -1675,6 +1747,9 @@ Lint/Debugger:
       - binding.pry
       - binding.remote_pry
       - binding.pry_remote
+      - Kernel.binding.pry
+      - Kernel.binding.remote_pry
+      - Kernel.binding.pry_remote
       - Pry.rescue
     Rails:
       - debugger
@@ -1695,7 +1770,7 @@ Lint/DeprecatedConstants:
   Enabled: true
   Severity: error
   VersionAdded: '1.8'
-  VersionChanged: '1.22'
+  VersionChanged: '1.40'
   # You can configure deprecated constants.
   # If there is an alternative method, you can set alternative value as `Alternative`.
   # And you can set the deprecated version as `DeprecatedVersion`.
@@ -1721,6 +1796,12 @@ Lint/DeprecatedConstants:
       DeprecatedVersion: '2.6'
     'Random::DEFAULT':
       Alternative: 'Random.new'
+      DeprecatedVersion: '3.0'
+    'Struct::Group':
+      Alternative: 'Etc::Group'
+      DeprecatedVersion: '3.0'
+    'Struct::Passwd':
+      Alternative: 'Etc::Passwd'
       DeprecatedVersion: '3.0'
 
 Lint/DeprecatedOpenSSLConstant:
@@ -1763,6 +1844,11 @@ Lint/DuplicateHashKey:
   VersionAdded: '0.34'
   VersionChanged: '0.77'
 
+Lint/DuplicateMagicComment:
+  Description: 'Check for duplicated magic comments.'
+  Enabled: pending
+  VersionAdded: '1.37'
+
 Lint/DuplicateMethods:
   Description: 'Check for duplicate method definitions.'
   Enabled: true
@@ -1801,7 +1887,7 @@ Lint/ElseLayout:
   VersionChanged: '1.2'
 
 Lint/EmptyBlock:
-  Description: 'This cop checks for blocks without a body.'
+  Description: 'Checks for blocks without a body.'
   Enabled: true
   Severity: error
   VersionAdded: '1.1'
@@ -1817,10 +1903,12 @@ Lint/EmptyClass:
   AllowComments: false
 
 Lint/EmptyConditionalBody:
-  Description: 'This cop checks for the presence of `if`, `elsif` and `unless` branches without a body.'
+  Description: 'Checks for the presence of `if`, `elsif` and `unless` branches without a body.'
   Enabled: true
+  SafeAutoCorrect: false
   AllowComments: true
   VersionAdded: '0.89'
+  VersionChanged: '1.34'
 
 Lint/EmptyEnsure:
   Description: 'Checks for empty ensure block.'
@@ -1958,18 +2046,19 @@ Lint/InheritException:
   VersionAdded: '0.41'
   VersionChanged: '1.26'
   # The default base class in favour of `Exception`.
-  EnforcedStyle: runtime_error
+  EnforcedStyle: standard_error
   SupportedStyles:
     - standard_error
     - runtime_error
 
 Lint/InterpolationCheck:
-  Description: 'Raise warning for interpolation in single q strs.'
+  Description: 'Checks for interpolation in a single quoted string.'
   Enabled: true
   Severity: error
   Safe: false
+  SafeAutoCorrect: false
   VersionAdded: '0.50'
-  VersionChanged: '0.87'
+  VersionChanged: '1.40'
 
 Lint/LambdaWithoutLiteralBlock:
   Description: 'Checks uses of lambda without a literal block.'
@@ -2016,7 +2105,7 @@ Lint/MissingCopEnableDirective:
 
 Lint/MissingSuper:
   Description: >-
-    This cop checks for the presence of constructors and lifecycle callbacks
+    Checks for the presence of constructors and lifecycle callbacks
     without calls to `super`.
   Enabled: false
   VersionAdded: '0.89'
@@ -2039,6 +2128,8 @@ Lint/NestedMethodDefinition:
   StyleGuide: '#no-nested-methods'
   Enabled: true
   Severity: error
+  AllowedMethods: []
+  AllowedPatterns: []
   VersionAdded: '0.32'
 
 Lint/NestedPercentLiteral:
@@ -2061,6 +2152,13 @@ Lint/NoReturnInBeginEndBlocks:
   Severity: error
   VersionAdded: '1.2'
 
+Lint/NonAtomicFileOperation:
+  Description: Checks for non-atomic file operations.
+  StyleGuide: '#atomic-file-operations'
+  Enabled: pending
+  VersionAdded: '1.31'
+  SafeAutoCorrect: false
+
 Lint/NonDeterministicRequireOrder:
   Description: 'Always sort arrays returned by Dir.glob when requiring files.'
   Enabled: true
@@ -2080,7 +2178,8 @@ Lint/NumberConversion:
   VersionAdded: '0.53'
   VersionChanged: '1.1'
   SafeAutoCorrect: false
-  IgnoredMethods: []
+  AllowedMethods: []
+  AllowedPatterns: []
   IgnoredClasses:
     - Time
     - DateTime
@@ -2102,7 +2201,9 @@ Lint/OrderedMagicComments:
   Description: 'Checks the proper ordering of magic comments and whether a magic comment is not placed before a shebang.'
   Enabled: true
   Severity: error
+  SafeAutoCorrect: false
   VersionAdded: '0.53'
+  VersionChanged: '1.37'
 
 Lint/OutOfRangeRegexpRef:
   Description: 'Checks for out of range reference for Regexp because it always returns nil.'
@@ -2245,6 +2346,11 @@ Lint/RequireParentheses:
   Severity: error
   VersionAdded: '0.18'
 
+Lint/RequireRangeParentheses:
+  Description: 'Checks that a range literal is enclosed in parentheses when the end of the range is at a line break.'
+  Enabled: pending
+  VersionAdded: '1.32'
+
 Lint/RequireRelativeSelfPath:
   Description: 'Checks for uses a file requiring itself with `require_relative`.'
   Enabled: pending
@@ -2381,7 +2487,7 @@ Lint/Syntax:
   VersionAdded: '0.9'
 
 Lint/ToEnumArguments:
-  Description: 'This cop ensures that `to_enum`/`enum_for`, called for the current method, has correct arguments.'
+  Description: 'Ensures that `to_enum`/`enum_for`, called for the current method, has correct arguments.'
   Enabled: pending
   VersionAdded: '1.1'
 
@@ -2392,12 +2498,12 @@ Lint/ToJSON:
   VersionAdded: '0.66'
 
 Lint/TopLevelReturnWithArgument:
-  Description: 'This cop detects top level return statements with argument.'
+  Description: 'Detects top level return statements with argument.'
   Enabled: true
   VersionAdded: '0.89'
 
 Lint/TrailingCommaInAttributeDeclaration:
-  Description: 'This cop checks for trailing commas in attribute declarations.'
+  Description: 'Checks for trailing commas in attribute declarations.'
   Enabled: true
   VersionAdded: '0.90'
 
@@ -2451,7 +2557,7 @@ Lint/UnreachableCode:
   VersionAdded: '0.9'
 
 Lint/UnreachableLoop:
-  Description: 'This cop checks for loops that will have at most one iteration.'
+  Description: 'Checks for loops that will have at most one iteration.'
   Enabled: true
   VersionAdded: '0.89'
   VersionChanged: '1.7'
@@ -2459,7 +2565,6 @@ Lint/UnreachableLoop:
     # RSpec uses `times` in its message expectations
     # eg. `exactly(2).times`
     - !ruby/regexp /(exactly|at_least|at_most)\(\d+\)\.times/
-  IgnoredPatterns: [] # deprecated
 
 Lint/UnusedBlockArgument:
   Description: 'Checks for unused block arguments.'
@@ -2516,6 +2621,12 @@ Lint/UselessAssignment:
   Severity: error
   VersionAdded: '0.11'
 
+Lint/UselessElseWithoutRescue:
+  Description: 'Checks for useless `else` in `begin..end` without `rescue`.'
+  Enabled: true
+  VersionAdded: '0.17'
+  VersionChanged: '1.31'
+
 Lint/UselessMethodDefinition:
   Description: 'Checks for useless method definitions.'
   Enabled: true
@@ -2523,6 +2634,11 @@ Lint/UselessMethodDefinition:
   VersionChanged: '0.91'
   Safe: false
   AllowComments: true
+
+Lint/UselessRescue:
+  Description: 'Checks for useless `rescue`s.'
+  Enabled: pending
+  VersionAdded: '1.43'
 
 Lint/UselessRuby2Keywords:
   Description: 'Finds unnecessary uses of `ruby2_keywords`.'
@@ -2565,7 +2681,8 @@ Metrics/AbcSize:
   VersionChanged: '1.5'
   # The ABC size is a calculated magnitude, so this number can be an Integer or
   # a Float.
-  IgnoredMethods: []
+  AllowedMethods: []
+  AllowedPatterns: []
   CountRepeatedAttributes: true
   Max: 17
 
@@ -2578,10 +2695,11 @@ Metrics/BlockLength:
   CountComments: false  # count full line comments?
   Max: 80
   CountAsOne: []
-  IgnoredMethods:
+  AllowedMethods:
     # By default, exclude the `#refine` method, as it tends to have larger
     # associated blocks.
     - refine
+  AllowedPatterns: []
   Exclude:
     - '**/*.gemspec'
     # Tests
@@ -2619,7 +2737,8 @@ Metrics/CyclomaticComplexity:
   Enabled: false
   VersionAdded: '0.25'
   VersionChanged: '0.81'
-  IgnoredMethods: []
+  AllowedMethods: []
+  AllowedPatterns: []
   Max: 6
 
 Metrics/MethodLength:
@@ -2632,8 +2751,8 @@ Metrics/MethodLength:
   CountComments: false  # count full line comments?
   Max: 80
   CountAsOne: []
-  ExcludedMethods: [] # deprecated, retained for backwards compatibility
-  IgnoredMethods: []
+  AllowedMethods: []
+  AllowedPatterns: []
   Exclude:
     # Migrations are one time thing
     - 'db/migrate/**/*'
@@ -2664,7 +2783,8 @@ Metrics/PerceivedComplexity:
   Enabled: false
   VersionAdded: '0.25'
   VersionChanged: '0.81'
-  IgnoredMethods: []
+  AllowedMethods: []
+  AllowedPatterns: []
   Max: 7
 
 ################## Migration #############################
@@ -2844,7 +2964,7 @@ Naming/HeredocDelimiterNaming:
   Severity: error
   VersionAdded: '0.50'
   ForbiddenDelimiters:
-    - !ruby/regexp '/(^|\s)(EO[A-Z]{1}|END)(\s|$)/'
+    - !ruby/regexp '/(^|\s)(EO[A-Z]{1}|END)(\s|$)/i'
 
 Naming/InclusiveLanguage:
   Description: 'Recommend the use of inclusive language instead of problematic terms.'
@@ -2909,7 +3029,6 @@ Naming/MethodName:
   #     - '\A\s*onSelectionCleared\s*'
   #
   AllowedPatterns: []
-  IgnoredPatterns: [] # deprecated
 
 Naming/MethodParameterName:
   Description: >-
@@ -2924,10 +3043,13 @@ Naming/MethodParameterName:
   AllowNamesEndingInNumbers: true
   # Allowed names that will not register an offense
   AllowedNames:
+    - as
     - at
     - by
+    - cc
     - db
     - id
+    - if
     - in
     - io
     - ip
@@ -3087,6 +3209,7 @@ Style/AccessModifierDeclarations:
     - inline
     - group
   AllowModifiersOnSymbols: true
+  SafeAutoCorrect: false
 
 Style/AccessorGrouping:
   Description: 'Checks for grouping of accessors in `class` and `module` bodies.'
@@ -3141,6 +3264,12 @@ Style/ArrayCoercion:
   Safe: false
   Enabled: false
   VersionAdded: '0.88'
+
+Style/ArrayIntersect:
+  Description: 'Use `array1.intersect?(array2)` instead of `(array1 & array2).any?`.'
+  Enabled: 'pending'
+  Safe: false
+  VersionAdded: '1.40'
 
 Style/ArrayJoin:
   Description: 'Use Array#join instead of Array#*.'
@@ -3229,7 +3358,7 @@ Style/BlockDelimiters:
     # This looks at the usage of a block's method to determine its type (e.g. is
     # the result of a `map` assigned to a variable or passed to another
     # method) but exceptions are permitted in the `ProceduralMethods`,
-    # `FunctionalMethods` and `IgnoredMethods` sections below.
+    # `FunctionalMethods` and `AllowedMethods` sections below.
     - semantic
     # The `braces_for_chaining` style enforces braces around single line blocks
     # and do..end around multi-line blocks, except for multi-line blocks whose
@@ -3270,7 +3399,7 @@ Style/BlockDelimiters:
     - let!
     - subject
     - watch
-  IgnoredMethods:
+  AllowedMethods:
     # Methods that can be either procedural or functional and cannot be
     # categorised from their usage alone, e.g.
     #
@@ -3287,6 +3416,7 @@ Style/BlockDelimiters:
     - lambda
     - proc
     - it
+  AllowedPatterns: []
   # The AllowBracesOnProceduralOneLiners option is ignored unless the
   # EnforcedStyle is set to `semantic`. If so:
   #
@@ -3310,7 +3440,7 @@ Style/BlockDelimiters:
   #   collection.each do |element| puts element end
   AllowBracesOnProceduralOneLiners: false
   # The BracesRequiredMethods overrides all other configurations except
-  # IgnoredMethods. It can be used to enforce that all blocks for specific
+  # AllowedMethods. It can be used to enforce that all blocks for specific
   # methods use braces. For example, you can use this to enforce Sorbet
   # signatures use braces even when the rest of your codebase enforces
   # the `line_count_based` style.
@@ -3331,9 +3461,18 @@ Style/CaseEquality:
   #   # good
   #   String === "string"
   AllowOnConstant: false
+  # If `AllowOnSelfClass` option is enabled, the cop will ignore violations when the receiver of
+  # the case equality operator is `self.class`.
+  #
+  #   # bad
+  #   some_class === object
+  #
+  #   # good
+  #   self.class === object
+  AllowOnSelfClass: false
 
 Style/CaseLikeIf:
-  Description: 'This cop identifies places where `if-elsif` constructions can be replaced with `case-when`.'
+  Description: 'Identifies places where `if-elsif` constructions can be replaced with `case-when`.'
   StyleGuide: '#case-vs-if-else'
   Enabled: true
   Safe: false
@@ -3393,10 +3532,11 @@ Style/ClassEqualityComparison:
   StyleGuide: '#instance-of-vs-class-comparison'
   Enabled: true
   VersionAdded: '0.93'
-  IgnoredMethods:
+  AllowedMethods:
     - ==
     - equal?
     - eql?
+  AllowedPatterns: []
 
 Style/ClassMethods:
   Description: 'Use self when defining module/class methods.'
@@ -3524,6 +3664,17 @@ Style/CommentedKeyword:
   VersionAdded: '0.51'
   VersionChanged: '1.19'
 
+Style/ComparableClamp:
+  Description: 'Enforces the use of `Comparable#clamp` instead of comparison by minimum and maximum.'
+  Enabled: pending
+  VersionAdded: '1.44'
+
+Style/ConcatArrayLiterals:
+  Description: 'Enforces the use of `Array#push(item)` instead of `Array#concat([item])` to avoid redundant array literals.'
+  Enabled: pending
+  Safe: false
+  VersionAdded: '1.41'
+
 Style/ConditionalAssignment:
   Description: >-
     Use the return value of `if` and `case` statements for
@@ -3583,7 +3734,7 @@ Style/Copyright:
 
 Style/DateTime:
   Description: 'Use Time over DateTime.'
-  StyleGuide: '#date--time'
+  StyleGuide: '#date-time'
   Enabled: false
   VersionAdded: '0.51'
   VersionChanged: '0.92'
@@ -3699,6 +3850,12 @@ Style/EmptyElse:
     - empty
     - nil
     - both
+  AllowComments: false
+
+Style/EmptyHeredoc:
+  Description: 'Checks for using empty heredoc to reduce redundancy.'
+  Enabled: pending
+  VersionAdded: '1.32'
 
 Style/EmptyLambdaParameter:
   Description: 'Omit parens for empty lambda parameters.'
@@ -3801,7 +3958,7 @@ Style/ExponentialNotation:
 
 Style/FetchEnvVar:
   Description: >-
-    This cop suggests `ENV.fetch` for the replacement of `ENV[]`.
+    Suggests `ENV.fetch` for the replacement of `ENV[]`.
   Reference:
     - https://rubystyle.guide/#hash-fetch-defaults
   Enabled: pending
@@ -3881,7 +4038,8 @@ Style/FormatStringToken:
   MaxUnannotatedPlaceholdersAllowed: 1
   VersionAdded: '0.49'
   VersionChanged: '1.0'
-  IgnoredMethods: []
+  AllowedMethods: []
+  AllowedPatterns: []
 
 Style/FrozenStringLiteralComment:
   Description: >-
@@ -3929,7 +4087,7 @@ Style/GuardClause:
   Enabled: true
   Severity: error
   VersionAdded: '0.20'
-  VersionChanged: '1.28'
+  VersionChanged: '1.31'
   # `MinBodyLength` defines the number of lines of the a body of an `if` or `unless`
   # needs to have to trigger this cop
   MinBodyLength: 1
@@ -3962,7 +4120,8 @@ Style/HashEachMethods:
   Safe: false
   VersionAdded: '0.80'
   VersionChanged: '1.16'
-  AllowedReceivers: []
+  AllowedReceivers:
+    - Thread.current
 
 Style/HashExcept:
   Description: >-
@@ -3970,7 +4129,9 @@ Style/HashExcept:
     that can be replaced with `Hash#except` method.
   Enabled: true
   Severity: error
+  Safe: false
   VersionAdded: '1.7'
+  VersionChanged: '1.39'
 
 Style/HashLikeCase:
   Description: >-
@@ -4010,6 +4171,8 @@ Style/HashSyntax:
     - never
     # accepts both shorthand and explicit use of hash literal value.
     - either
+    # forces use of the 3.1 syntax only if all values can be omitted in the hash.
+    - consistent
   # Force hashes that have a symbol value to use hash rockets
   UseHashRocketsWithSymbolValues: false
   # Do not suggest { a?: 1 } over { :a? => 1 } in ruby19 style
@@ -4140,6 +4303,35 @@ Style/InverseMethods:
     :select: :reject
     :select!: :reject!
 
+Style/InvertibleUnlessCondition:
+  Description: 'Favor `if` with inverted condition over `unless`.'
+  Enabled: false
+  VersionAdded: '1.44'
+  # `InverseMethods` are methods that can be inverted in a `unless` condition.
+  # The relationship of inverse methods needs to be defined in both directions.
+  # Keys and values both need to be defined as symbols.
+  InverseMethods:
+    :!=: :==
+    :>: :<=
+    :<=: :>
+    :<: :>=
+    :>=: :<
+    :!~: :=~
+    :zero?: :nonzero?
+    :nonzero?: :zero?
+    :any?: :none?
+    :none?: :any?
+    :even?: :odd?
+    :odd?: :even?
+    # `ActiveSupport` defines some common inverse methods. They are listed below,
+    # and not enabled by default.
+    # :present?: :blank?
+    # :blank?: :present?
+    # :include?: :exclude?
+    # :exclude?: :include?
+    # :one?: :many?
+    # :many?: :one?
+
 Style/IpAddresses:
   Description: "Don't include literal IP addresses in code."
   Enabled: false
@@ -4197,11 +4389,42 @@ Style/LineEndConcatenation:
   VersionAdded: '0.18'
   VersionChanged: '0.64'
 
+Style/MagicCommentFormat:
+  Description: 'Use a consistent style for magic comments.'
+  Enabled: pending
+  VersionAdded: '1.35'
+  EnforcedStyle: snake_case
+  SupportedStyles:
+    # `snake` will enforce the magic comment is written
+    # in snake case (words separated by underscores).
+    # Eg: froze_string_literal: true
+    - snake_case
+    # `kebab` will enforce the magic comment is written
+    # in kebab case (words separated by hyphens).
+    # Eg: froze-string-literal: true
+    - kebab_case
+  DirectiveCapitalization: lowercase
+  ValueCapitalization: ~
+  SupportedCapitalizations:
+    - lowercase
+    - uppercase
+
+Style/MapCompactWithConditionalBlock:
+  Description: 'Prefer `select` or `reject` over `map { ... }.compact`.'
+  Enabled: pending
+  VersionAdded: '1.30'
+
 Style/MapToHash:
   Description: 'Prefer `to_h` with a block over `map.to_h`.'
   Enabled: pending
   VersionAdded: '1.24'
   Safe: false
+
+Style/MapToSet:
+  Description: 'Prefer `to_set` with a block over `map.to_set`.'
+  Enabled: pending
+  Safe: false
+  VersionAdded: '1.42'
 
 Style/MethodCallWithArgsParentheses:
   Description: 'Use parentheses for method calls with arguments.'
@@ -4210,9 +4433,8 @@ Style/MethodCallWithArgsParentheses:
   VersionAdded: '0.47'
   VersionChanged: '1.7'
   IgnoreMacros: true
-  IgnoredMethods: []
+  AllowedMethods: []
   AllowedPatterns: []
-  IgnoredPatterns: [] # deprecated
   IncludedMacros: []
   AllowParenthesesInMultilineCall: false
   AllowParenthesesInChaining: false
@@ -4228,7 +4450,8 @@ Style/MethodCallWithoutArgsParentheses:
   StyleGuide: '#method-invocation-parens'
   Enabled: true
   Severity: error
-  IgnoredMethods: []
+  AllowedMethods: []
+  AllowedPatterns: []
   VersionAdded: '0.47'
   VersionChanged: '0.55'
 
@@ -4260,6 +4483,12 @@ Style/MinMax:
   Enabled: true
   Severity: error
   VersionAdded: '0.50'
+
+Style/MinMaxComparison:
+  Description: 'Enforces the use of `max` or `min` instead of comparison for greater or less.'
+  Enabled: pending
+  Safe: false
+  VersionAdded: '1.42'
 
 Style/MissingElse:
   Description: >-
@@ -4434,7 +4663,7 @@ Style/NegatedIf:
 
 Style/NegatedIfElseCondition:
   Description: >-
-    This cop checks for uses of `if-else` and ternary operators with a negated condition
+    Checks for uses of `if-else` and ternary operators with a negated condition
     which can be simplified by inverting condition and swapping branches.
   Enabled: true
   Severity: error
@@ -4606,6 +4835,7 @@ Style/NumericLiterals:
   Strict: false
   # You can specify allowed numbers. (e.g. port number 3000, 8080, and etc)
   AllowedNumbers: []
+  AllowedPatterns: []
 
 Style/NumericPredicate:
   Description: >-
@@ -4626,7 +4856,8 @@ Style/NumericPredicate:
   SupportedStyles:
     - predicate
     - comparison
-  IgnoredMethods: []
+  AllowedMethods: []
+  AllowedPatterns: []
   # Exclude RSpec specs because assertions like `expect(1).to be > 0` cause
   # false positives.
   Exclude:
@@ -4665,6 +4896,12 @@ Style/OpenStructUse:
 
   Enabled: pending
   VersionAdded: '1.23'
+
+Style/OperatorMethodCall:
+  Description: 'Checks for redundant dot before operator method call.'
+  StyleGuide: '#operator-method-call'
+  Enabled: pending
+  VersionAdded: '1.37'
 
 Style/OptionHash:
   Description: "Don't use option hashes when you can use keyword arguments."
@@ -4823,10 +5060,12 @@ Style/RedundantArgument:
   Severity: error
   Safe: false
   VersionAdded: '1.4'
-  VersionChanged: '1.7'
+  VersionChanged: '1.40'
   Methods:
     # Array#join
     join: ''
+    # Array#sum
+    sum: 0
     # String#split
     split: ' '
     # String#chomp
@@ -4865,6 +5104,22 @@ Style/RedundantConditional:
   Severity: error
   VersionAdded: '0.50'
 
+Style/RedundantConstantBase:
+  Description: Avoid redundant `::` prefix on constant.
+  Enabled: pending
+  VersionAdded: '1.40'
+
+Style/RedundantDoubleSplatHashBraces:
+  Description: 'Checks for redundant uses of double splat hash braces.'
+  Enabled: pending
+  VersionAdded: '1.41'
+
+Style/RedundantEach:
+  Description: 'Checks for redundant `each`.'
+  Enabled: pending
+  Safe: false
+  VersionAdded: '1.38'
+
 Style/RedundantException:
   Description: "Checks for an obsolete RuntimeException argument in raise/fail."
   StyleGuide: '#no-explicit-runtimeerror'
@@ -4901,6 +5156,11 @@ Style/RedundantFreeze:
   VersionAdded: '0.34'
   VersionChanged: '0.66'
 
+Style/RedundantHeredocDelimiterQuotes:
+  Description: 'Checks for redundant heredoc delimiter quotes.'
+  Enabled: pending
+  VersionAdded: '1.45'
+
 Style/RedundantInitialize:
   Description: 'Checks for redundant `initialize` methods.'
   Enabled: pending
@@ -4913,7 +5173,9 @@ Style/RedundantInterpolation:
   Description: 'Checks for strings that are just an interpolated expression.'
   Enabled: true
   Severity: error
+  SafeAutoCorrect: false
   VersionAdded: '0.76'
+  VersionChanged: '1.30'
 
 Style/RedundantParentheses:
   Description: "Checks for parentheses that seem not to serve any purpose."
@@ -4984,6 +5246,11 @@ Style/RedundantSortBy:
   Severity: error
   VersionAdded: '0.36'
 
+Style/RedundantStringEscape:
+  Description: 'Checks for redundant escapes in string literals.'
+  Enabled: pending
+  VersionAdded: '1.37'
+
 Style/RegexpLiteral:
   Description: 'Use / or %r around regular expressions.'
   StyleGuide: '#percent-r'
@@ -5002,6 +5269,12 @@ Style/RegexpLiteral:
   # If `false`, the cop will always recommend using `%r` if one or more slashes
   # are found in the regexp string.
   AllowInnerSlashes: false
+
+Style/RequireOrder:
+  Description: Sort `require` and `require_relative` in alphabetical order.
+  Enabled: false
+  SafeAutoCorrect: false
+  VersionAdded: '1.40'
 
 Style/RescueModifier:
   Description: 'Avoid using rescue in its modifier form.'
@@ -5034,10 +5307,10 @@ Style/ReturnNil:
 
 Style/SafeNavigation:
   Description: >-
-    This cop transforms usages of a method call safeguarded by
+    Transforms usages of a method call safeguarded by
     a check for the existence of the object to
     safe navigation (`&.`).
-    Auto-correction is unsafe as it assumes the object will
+    Autocorrection is unsafe as it assumes the object will
     be `nil` or truthy, but never `false`.
   Enabled: true
   Severity: error
@@ -5077,7 +5350,6 @@ Style/SelfAssignment:
     been used.
   StyleGuide: '#self-assignment'
   Enabled: true
-  Severity: error
   VersionAdded: '0.19'
   VersionChanged: '0.29'
 
@@ -5274,7 +5546,7 @@ Style/StructInheritance:
   VersionChanged: '1.20'
 
 Style/SwapValues:
-  Description: 'This cop enforces the use of shorthand-style swapping of 2 variables.'
+  Description: 'Enforces the use of shorthand-style swapping of 2 variables.'
   StyleGuide: '#values-swapping'
   Enabled: pending
   VersionAdded: '1.1'
@@ -5304,13 +5576,14 @@ Style/SymbolProc:
   Severity: error
   Safe: false
   VersionAdded: '0.26'
-  VersionChanged: '1.28'
+  VersionChanged: '1.40'
   AllowMethodsWithArguments: false
-  # A list of method names to be ignored by the check.
+  # A list of method names to be always allowed by the check.
   # The names should be fairly unique, otherwise you'll end up ignoring lots of code.
-  IgnoredMethods:
+  AllowedMethods:
     - respond_to
     - define_method
+  AllowedPatterns: []
   AllowComments: false
 
 Style/TernaryParentheses:
@@ -5327,7 +5600,7 @@ Style/TernaryParentheses:
   AllowSafeAssignment: true
 
 Style/TopLevelMethodDefinition:
-  Description: 'This cop looks for top-level method definitions.'
+  Description: 'Looks for top-level method definitions.'
   StyleGuide: '#top-level-methods'
   Enabled: false
   VersionAdded: '1.15'
@@ -5562,6 +5835,19 @@ Style/YodaCondition:
   Safe: false
   VersionAdded: '0.49'
   VersionChanged: '0.75'
+
+Style/YodaExpression:
+  Description: 'Forbid the use of yoda expressions.'
+  Enabled: false
+  Safe: false
+  VersionAdded: '1.42'
+  VersionChanged: '1.43'
+  SupportedOperators:
+    - '*'
+    - '+'
+    - '&'
+    - '|'
+    - '^'
 
 Style/ZeroLengthPredicate:
   Description: 'Use #empty? when testing for objects of length 0.'


### PR DESCRIPTION
# Background
Align Rubocop configuration to new Rubocop version. Taken from: https://raw.githubusercontent.com/rubocop/rubocop/master/config/default.yml

## Did you make sure to?
### Project Management
- [ ] Review it as needed with the technical team leader?
- [ ] Attach the PR to the Trello card?

### PR
- [x] Assign yourself to the PR
- [ ] Add at least one reviewer

### Before-Merge
- [ ] Update the repos dependent on those rules - delete the current cached rubocop.yml, and run `rubocop` again to refresh
- [ ] Validate changes against affected repositories, and if needed, prepare PRs to update repositories according to changes

### Post-Merge
- [ ] Verify that your Trello card was moved to today's release and that it was announced in #releases slack channel
