### PR TITLE
Fix deprecated configuration

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1074,7 +1074,6 @@ Layout/LineContinuationSpacing:
   Description: 'Checks the spacing in front of backslash in line continuations.'
   Enabled: pending
   AutoCorrect: true
-  SafeAutoCorrect: true
   VersionAdded: '1.31'
   EnforcedStyle: space
   SupportedStyles:
@@ -2677,7 +2676,6 @@ Lint/UselessMethodDefinition:
   VersionAdded: '0.90'
   VersionChanged: '0.91'
   Safe: false
-  AllowComments: true
 
 Lint/UselessRescue:
   Description: 'Checks for useless `rescue`s.'
@@ -3306,7 +3304,6 @@ Style/ArgumentsForwarding:
   Description: 'Use arguments forwarding.'
   StyleGuide: '#arguments-forwarding'
   Enabled: pending
-  AllowOnlyRestArgument: true
   UseAnonymousForwarding: true
   VersionAdded: '1.1'
 


### PR DESCRIPTION
```
 Warning: obsolete parameter `AllowOnlyRestArgument` (for `Style/ArgumentsForwarding`) found in .rubocop-https---raw-githubusercontent-com-TailorBrands-tailor-rubocop-master-rubocop-yml
  `AllowOnlyRestArgument` has no effect with TargetRubyVersion >= 3.2.
  Warning: Layout/LineContinuationSpacing does not support SafeAutoCorrect parameter.
  
  Supported parameters are:
  
    - Enabled
    - EnforcedStyle
    - SupportedStyles
  Warning: Lint/UselessMethodDefinition does not support AllowComments parameter.
  
  Supported parameters are:
  
    - Enabled
    - AutoCorrect
  Warning: obsolete parameter `AllowOnlyRestArgument` (for `Style/ArgumentsForwarding`) found in .rubocop.yml
  `AllowOnlyRestArgument` has no effect with TargetRubyVersion >= 3.2.
  Warning: Layout/LineContinuationSpacing does not support SafeAutoCorrect parameter.
  
  Supported parameters are:
  
    - Enabled
    - EnforcedStyle
    - SupportedStyles
  Warning: Lint/UselessMethodDefinition does not support AllowComments parameter.
  
  Supported parameters are:
  
    - Enabled
    - AutoCorrect
```