### PR TITLE
Disable redundant `RSpec/MultipleMemoizedHelpers` rubocop rule

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -6133,3 +6133,10 @@ RSpec/RepeatedExample:
   Severity: error
   VersionAdded: "0.9"
   MaxRepeatCount: 1
+
+RSpec/MultipleMemoizedHelpers:
+  Description: "Checks for multiple memoized helpers in a single example."
+  Enabled: false
+  Severity: error
+  VersionAdded: "0.9"
+  MaxMemoizedHelpers: 1


### PR DESCRIPTION
In this PR - I would like to disable `RSpec/MultipleMemoizedHelpers` rubocop rule since I'm not sure this is a rule we would need to be strict about  - https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecmultiplememoizedhelpers