### PR TITLE
Remove obsolete IgnoreCopDirectives option from Layout/LineLength

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea/
+.worktrees/

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1145,9 +1145,6 @@ Layout/LineLength:
   URISchemes:
     - http
     - https
-  # The IgnoreCopDirectives option causes the LineLength rule to ignore cop
-  # directives like '# rubocop: enable ...' when calculating a line's length.
-  IgnoreCopDirectives: true
   # The AllowedPatterns option is a list of !ruby/regexp and/or string
   # elements. Strings will be converted to Regexp objects. A line that matches
   # any regular expression listed in this option will be ignored by LineLength.


### PR DESCRIPTION
## Summary

This PR removes the obsolete `IgnoreCopDirectives` option from the `Layout/LineLength` rule in `rubocop.yml`. This option is no longer supported in modern RuboCop versions.

Additionally, adds `.worktrees` to `.gitignore` to ignore git worktree directories.

## Test plan

- [x] Configuration loads without errors
- [x] No new linting violations introduced
- [x] Changes validated against RuboCop configuration schema