### PR TITLE
chore: align rubocop config with installed cop set

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -543,7 +543,6 @@ Layout/ClosingParenthesisIndentation:
   Enabled: true
   Severity: error
   VersionAdded: "0.49"
-  VersionChanged: "1.86"
 
 Layout/CommentIndentation:
   Description: "Indentation of comments."
@@ -1067,10 +1066,6 @@ Layout/IndentationWidth:
   VersionAdded: "0.49"
   # Number of spaces for each indentation level.
   Width: 2
-  EnforcedStyleAlignWith: start_of_line
-  SupportedStylesAlignWith:
-    - start_of_line
-    - relative_to_receiver
   AllowedPatterns: []
 
 Layout/InitialIndentation:
@@ -1151,9 +1146,6 @@ Layout/LineLength:
   URISchemes:
     - http
     - https
-  AllowRBSInlineAnnotation: false
-  # IgnoreCopDirectives was renamed to AllowCopDirectives in 1.82.
-  AllowCopDirectives: true
   SplitStrings: false
   # The AllowedPatterns option is a list of !ruby/regexp and/or string
   # elements. Strings will be converted to Regexp objects. A line that matches
@@ -1846,12 +1838,6 @@ Lint/Debugger:
     debug.rb:
       - debug/open
       - debug/start
-
-Lint/DataDefineOverride:
-  Description: "Disallow overriding the Data built-in methods via Data.define."
-  Enabled: true
-  Severity: error
-  VersionAdded: "1.85"
 
 Lint/DeprecatedClassMethods:
   Description: "Check for deprecated class method calls."
@@ -2558,7 +2544,6 @@ Lint/SafeNavigationConsistency:
   Severity: error
   VersionAdded: "0.55"
   VersionChanged: "1.85"
-  SafeAutoCorrect: false
   AllowedMethods:
     - present?
     - blank?
@@ -2750,12 +2735,6 @@ Lint/UnreachableLoop:
     # eg. `exactly(2).times`
     - !ruby/regexp /(exactly|at_least|at_most)\(\d+\)\.times/
 
-Lint/UnreachablePatternBranch:
-  Description: "Checks for unreachable in pattern branches after an unconditional catch-all pattern."
-  Enabled: true
-  Severity: error
-  VersionAdded: "1.85"
-
 Lint/UnusedBlockArgument:
   Description: "Checks for unused block arguments."
   StyleGuide: "#underscore-unused-vars"
@@ -2864,10 +2843,8 @@ Lint/UselessOr:
   Description: "Checks for || after methods that always return truthy values."
   Enabled: true
   Severity: error
-  SafeAutoCorrect: false
   AutoCorrect: contextual
   VersionAdded: "1.76"
-  VersionChanged: "1.82"
 
 Lint/UselessRuby2Keywords:
   Description: "Finds unnecessary uses of `ruby2_keywords`."
@@ -4177,18 +4154,6 @@ Style/EmptyCaseCondition:
   Severity: error
   VersionAdded: "0.40"
 
-Style/EmptyClassDefinition:
-  Description: "Enforces consistent style for empty class definitions."
-  Enabled: true
-  Severity: error
-  VersionAdded: "1.84"
-  VersionChanged: "1.86"
-  EnforcedStyle: class_keyword
-  SupportedStyles:
-    - class_keyword
-    - class_new
-  AllowedParentClasses: []
-
 Style/EmptyElse:
   Description: "Avoid empty else-clauses."
   Enabled: true
@@ -4352,13 +4317,6 @@ Style/FileNull:
   Enabled: true
   Severity: error
   VersionAdded: "1.69"
-
-Style/FileOpen:
-  Description: "Checks for File.open without a block, which can leak file descriptors."
-  Enabled: true
-  Severity: error
-  Safe: false
-  VersionAdded: "1.85"
 
 Style/FileRead:
   Description: "Favor `File.(bin)read` convenience methods."
@@ -4552,16 +4510,6 @@ Style/HashLikeCase:
   # `MinBranchesCount` defines the number of branches `case` needs to have
   # to trigger this cop
   MinBranchesCount: 3
-
-Style/HashLookupMethod:
-  Description: "Enforces the use of either Hash#[] or Hash#fetch for hash lookup."
-  Enabled: false
-  Safe: false
-  VersionAdded: "1.84"
-  EnforcedStyle: brackets
-  SupportedStyles:
-    - brackets
-    - fetch
 
 Style/HashSyntax:
   Description: >-
@@ -4861,13 +4809,6 @@ Style/MapIntoArray:
   VersionAdded: "1.63"
   Safe: false
 
-Style/MapJoin:
-  Description: "Checks for redundant map(&:to_s) before join."
-  Enabled: true
-  Severity: error
-  Safe: false
-  VersionAdded: "1.85"
-
 Style/MapToHash:
   Description: "Prefer `to_h` with a block over `map.to_h`."
   Enabled: true
@@ -4892,7 +4833,6 @@ Style/MethodCallWithArgsParentheses:
   AllowedMethods: []
   AllowedPatterns: []
   IncludedMacros: []
-  IncludedMacroPatterns: []
   AllowParenthesesInMultilineCall: false
   AllowParenthesesInChaining: false
   AllowParenthesesInCamelCaseMethod: false
@@ -5010,12 +4950,6 @@ Style/ModuleFunction:
     - forbidden
   Autocorrect: false
   SafeAutoCorrect: false
-
-Style/ModuleMemberExistenceCheck:
-  Description: "Checks for usage of Module methods returning arrays that can be replaced with equivalent predicates."
-  Enabled: true
-  Severity: error
-  VersionAdded: "1.82"
 
 Style/MultilineBlockChain:
   Description: "Avoid multi-line chains of blocks."
@@ -5156,12 +5090,6 @@ Style/NegatedWhile:
   Enabled: true
   Severity: error
   VersionAdded: "0.20"
-
-Style/NegativeArrayIndex:
-  Description: "Use negative array indices instead of calculating array length minus a value."
-  Enabled: true
-  Severity: error
-  VersionAdded: "1.84"
 
 Style/NestedFileDirname:
   Description: "Checks for nested `File.dirname`."
@@ -5351,16 +5279,6 @@ Style/ObjectThen:
     - then
     - yield_self
 
-Style/OneClassPerFile:
-  Description: "Checks that each source file defines at most one top-level class or module."
-  Enabled: false
-  VersionAdded: "1.85"
-  VersionChanged: "1.86"
-  AllowedClasses: []
-  Exclude:
-    - "spec/**/*"
-    - "test/**/*"
-
 Style/OneLineConditional:
   Description: >-
     Favor the ternary operator (?:) or multi-line constructs over
@@ -5456,15 +5374,6 @@ Style/ParenthesesAroundCondition:
   AllowSafeAssignment: true
   AllowInMultilineConditions: false
 
-Style/PartitionInsteadOfDoubleSelect:
-  Description: >-
-    Checks for consecutive select/filter/find_all and reject calls
-    on the same receiver with the same block body. Use partition instead.
-  Enabled: true
-  Severity: error
-  Safe: false
-  VersionAdded: "1.85"
-
 Style/PercentLiteralDelimiters:
   Description: "Use `%`-literal delimiters consistently."
   StyleGuide: "#percent-literal-braces"
@@ -5499,13 +5408,6 @@ Style/PerlBackrefs:
   Enabled: true
   Severity: error
   VersionAdded: "0.13"
-
-Style/PredicateWithKind:
-  Description: "Prefer any?(Klass) to any? { |x| x.is_a?(Klass) }."
-  Enabled: true
-  Severity: error
-  SafeAutoCorrect: false
-  VersionAdded: "1.85"
 
 Style/PreferredHashMethods:
   Description: "Checks use of `has_key?` and `has_value?` Hash methods."
@@ -5561,13 +5463,6 @@ Style/RandomWithOffset:
   Enabled: true
   Severity: error
   VersionAdded: "0.52"
-
-Style/ReduceToHash:
-  Description: "Use to_h { ... } instead of each_with_object, inject, or reduce to build a hash."
-  Enabled: true
-  Severity: error
-  Safe: false
-  VersionAdded: "1.85"
 
 Style/RedundantArgument:
   Description: "Check for a redundant argument passed to certain methods."
@@ -5750,12 +5645,6 @@ Style/RedundantLineContinuation:
   Severity: error
   VersionAdded: "1.49"
 
-Style/RedundantMinMaxBy:
-  Description: "Identifies places where max_by/min_by can be replaced by max/min."
-  Enabled: true
-  Severity: error
-  VersionAdded: "1.85"
-
 Style/RedundantParentheses:
   Description: "Checks for parentheses that seem not to serve any purpose."
   Enabled: true
@@ -5843,13 +5732,6 @@ Style/RedundantStringEscape:
   Severity: error
   VersionAdded: "1.37"
 
-Style/RedundantStructKeywordInit:
-  Description: "Checks for redundant keyword_init option for Struct.new."
-  Enabled: false
-  SafeAutoCorrect: false
-  VersionAdded: "1.85"
-  VersionChanged: "1.86"
-
 Style/RegexpLiteral:
   Description: "Use / or %r around regular expressions."
   StyleGuide: "#percent-r"
@@ -5914,13 +5796,6 @@ Style/ReturnNilInPredicateMethodDefinition:
   AllowedPatterns: []
   VersionAdded: "1.53"
 
-Style/ReverseFind:
-  Description: "Use `arr.rfind` instead of `arr.reverse.find`."
-  Enabled: true
-  Severity: error
-  Safe: false
-  VersionAdded: "1.84"
-
 Style/SafeNavigation:
   Description: >-
     Transforms usages of a method call safeguarded by
@@ -5960,20 +5835,6 @@ Style/Sample:
   Enabled: true
   Severity: error
   VersionAdded: "0.30"
-
-Style/SelectByKind:
-  Description: "Prefer grep/grep_v to select/reject/find/detect with a kind check."
-  Enabled: true
-  Severity: error
-  SafeAutoCorrect: false
-  VersionAdded: "1.85"
-
-Style/SelectByRange:
-  Description: "Prefer grep/grep_v to select/reject/find/detect with a range check."
-  Enabled: true
-  Severity: error
-  SafeAutoCorrect: false
-  VersionAdded: "1.85"
 
 Style/SelectByRegexp:
   Description: "Prefer grep/grep_v to select/reject with a regexp match."
@@ -6254,13 +6115,6 @@ Style/SymbolProc:
     - define_method
   AllowedPatterns: []
   AllowComments: false
-
-Style/TallyMethod:
-  Description: "Prefer Enumerable#tally over manual counting patterns."
-  Enabled: true
-  Severity: error
-  Safe: false
-  VersionAdded: "1.85"
 
 Style/TernaryParentheses:
   Description: "Checks for use of parentheses around ternary conditions."
@@ -6579,10 +6433,3 @@ RSpec/LeakyLocalVariable:
   Severity: error
   VersionAdded: "3.8"
 
-RSpec/Output:
-  Description: "Checks for the use of output calls like puts and print in specs."
-  Enabled: true
-  Severity: error
-  AutoCorrect: contextual
-  SafeAutoCorrect: false
-  VersionAdded: "3.9"


### PR DESCRIPTION
## Summary
- Remove 19 cop entries unknown to the current RuboCop release (Lint/Style/RSpec)
- Drop unsupported parameters from 6 existing cops across Layout/Lint/Style
- Eliminates the super-linter warnings about unrecognized cops and parameters